### PR TITLE
💄 style: change contrast for codeblocks

### DIFF
--- a/sass/syntax/syntax-ayu-dark.scss
+++ b/sass/syntax/syntax-ayu-dark.scss
@@ -1,6 +1,9 @@
 .z-code {
   color: #bfbab0;
-  background-color: #191919;
+  background-color: #151515;
+}
+[data-theme="light"] .z-code {
+  background-color: #272430
 }
 .z-comment,
 .z-punctuation.z-definition.z-comment {


### PR DESCRIPTION
Lowers the contrast for codeblocks' background in light theme and increases it for the dark theme.