### PR TITLE
🐛 fix: ensure text remains visible during webfont load

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1,6 +1,7 @@
 @font-face {
   font-family: 'Inter';
   src: url('fonts/Inter.ttf');
+  font-display: swap;
 }
 @import 'parts/_cards.scss';
 @import 'parts/_code.scss';


### PR DESCRIPTION
Improves Lighthouse score.