### PR TITLE
💄 style: don't fully invert images in dark theme

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -61,7 +61,7 @@
   --accent-color: #ff9a8c;
 
   .invertable-image {
-    filter: invert(1);
+    filter: invert(.88);
   }
 }
 


### PR DESCRIPTION
It washes out the contrast a bit, but a pure white background on a picture, which matches the background of the light theme, will now perfectly match the dark theme background.