### PR TITLE
✨ feat: add link to commit history on updated articles

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -69,6 +69,7 @@ last_updated_on = "Última actualización el"
 show_original_quote = "Mostrar cita original"
 show_translation = "Mostrar traducción"
 load_comments = "Cargar comentarios"
+see_changes = "Ver cambios"
 # Quotation marks for multilingual quote shortcode.
 open_quotation_mark = "«"
 close_quotation_mark = "»"
@@ -113,6 +114,7 @@ last_updated_on = "Última actualizació el"
 show_original_quote = "Mostra la cita original"
 show_translation = "Mostra la traducció"
 load_comments = "Carregar comentaris"
+see_changes = "Veure canvis"
 # Quotation marks for multilingual quote shortcode.
 open_quotation_mark = "«"
 close_quotation_mark = "»"
@@ -132,6 +134,17 @@ recent_posts = "Publicacions recents"
 language_name.ca = "Català"
 language_name.en = "English"
 language_name.es = "Español"
+
+# Remote repository for your Zola site.
+# Only used to link to the commit history of updated posts, right next to the updated date.
+# Supports GitHub, GitLab and Gitea.
+remote_repository_url = "https://github.com/welpo/tabi"
+# Set this to "auto" to try and auto-detect the platform based on the repository URL.
+# Accepted values are "github", "gitlab", and "gitea".
+# Defaults to "auto".
+remote_repository_git_platform = "auto"
+# Branch in the repo hosting the Zola site. Defaults to "main".
+remote_repository_branch = "main"
 
 # Enable JavaScript theme toggler to allow users to switch between dark/light mode.
 # Also enables automatic switching based on user's OS-level theme settings.

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,7 @@
 {% import "macros/format_date.html" as macros_format_date %}
 {% import "macros/add_comments.html" as macros_add_comments %}
 {% import "macros/table_of_contents.html" as macros_toc %}
+{% import "macros/create_history_url.html" as macros_create_history_url %}
 
 <!DOCTYPE html>
 <html lang="{{ lang }}" {% if config.extra.default_theme -%}

--- a/templates/macros/content.html
+++ b/templates/macros/content.html
@@ -32,6 +32,9 @@
 
             {% if page.updated %}
                 </ul><ul class="meta last-updated"><li>{%- if lang != config.default_language %} {{ trans(key="last_updated_on" | safe, lang=lang) }} {% else %} Last updated on {% endif %} {{ macros_format_date::format_date(date=page.updated, short=true) }}</li>
+                {% if config.extra.remote_repository_url %}
+                    <li>&nbsp;{{ separator }}&nbsp;<a href="{{ macros_create_history_url::create_history_url(relative_path=page.relative_path) }}" target="_blank" rel="noopener noreferrer">{%- if lang != config.default_language -%}{{ trans(key="see_changes" | safe, lang=lang) }}{% else %}See changes{%- endif -%}<small> ↗</small></a></li>
+                {% endif %}
             {% endif %}
         </ul>
 

--- a/templates/macros/create_history_url.html
+++ b/templates/macros/create_history_url.html
@@ -1,0 +1,30 @@
+{% macro create_history_url(relative_path) %}
+
+{% set repository_url = config.extra.remote_repository_url | trim_end_matches(pat='/') %}
+{% set branch = config.extra.remote_repository_branch | default(value="main") %}
+{% set git_platform = config.extra.remote_repository_git_platform | default(value="auto") %}
+
+{# Auto-detect the git platform based on the URL#}
+{% if git_platform == "auto" %}
+    {% if repository_url is containing("github.") %}
+        {% set git_platform = "github" %}
+    {% elif repository_url is containing("gitea.") %}
+        {% set git_platform = "gitea" %}
+    {% elif repository_url is containing("gitlab.") %}
+        {% set git_platform = "gitlab" %}
+    {% endif %}
+{% endif %}
+
+{# Generate the commit history URL based on the git platform #}
+{% if git_platform == "github" %}
+    {{ repository_url ~ '/commits/' ~ branch ~ '/content/' }}{{ relative_path | urlencode }}
+{% elif git_platform == "gitea" %}
+    {{ repository_url ~ '/commits/branch/' ~ branch ~ '/' }}{{ relative_path | urlencode }}
+{% elif git_platform == "gitlab" %}
+    {{ repository_url ~ '/-/commits/' ~ branch ~ '/' }}{{ relative_path | urlencode }}
+{% else %}
+    {# Throw an error with a direct link to report a bug for unsupported or unspecified platforms #}
+    {{ throw(message="ERROR: Unknown, unsupported, or unspecified git platform. If you're using a custom domain, please specify the 'git_platform' in the config. If you think this is a bug, report it [here](https://github.com/welpo/tabi/issues/new?assignees=&labels=bug&template=bug_report.md&title=Unsupported%20Git%20Platform%20Detected).") }}
+{% endif %}
+
+{% endmacro %}

--- a/theme.toml
+++ b/theme.toml
@@ -26,6 +26,17 @@ language_name.ca = "Català"
 language_name.en = "English"
 language_name.es = "Español"
 
+# Remote repository for your Zola site.
+# Only used to link to the commit history of updated posts, right next to the updated date.
+# Supports GitHub, GitLab and Gitea.
+remote_repository_url = "https://github.com/welpo/tabi"
+# Set this to "auto" to try and auto-detect the platform based on the repository URL.
+# Accepted values are "github", "gitlab", and "gitea".
+# Defaults to "auto".
+remote_repository_git_platform = "auto"
+# Branch in the repo hosting the Zola site. Defaults to "main".
+remote_repository_branch = "main"
+
 # Enable JavaScript theme toggler to allow users to switch between dark/light mode.
 # Also enables automatic switching based on user's OS-level theme settings.
 # If disabled, your site will only use the theme specified in the `default_theme` variable.


### PR DESCRIPTION
<details>
  <summary>TL;DR</summary>

- Add  a "See changes" link to the commit history of updated articles.
- Works with GitHub, GitLab, and Gitea.
- See screenshot below.

</details>

### Features

- Introduces a feature for sites hosted on GitHub, GitLab, or Gitea, that automatically attaches a "See changes" link to the commit history of an article right next to its 'last updated' date. This facilitates direct access to version history for updated articles.
- Provides seamless integration with popular Git platforms: GitHub, GitLab, and Gitea.
- Supports auto-detection of the Git platform based on the repository URL. For manual specification, the Git platform can be set in the TOML configuration.

### Implementation details

- Introduces a new Tera macro, `create_history_url`, to generate the commit history URLs based on each platform's URL template.
- Adds three settings in `config.toml` to specify remote repository details (URL and branch) and either opt for the auto-detection feature or set the Git platform manually.
- Adds translations for the new string.
- Integrated the feature into the articles metadata section, displayed adjacent to the last updated date:

![See changes screenshot](https://github.com/welpo/tabi/assets/6399341/5b8e7042-e9d1-4848-aa9f-d14b62020df7)

### Note ⚠️

- For repository URLs not containing standard identifiers like "github.", "gitea.", or "gitlab.", it's necessary to manually set the `git_platform` in the config. This ensures accurate behavior since auto-detection will not be work for non-standard URLs.