### PR TITLE
✨ feat(footer): Add link to remote repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The content outside the front matter will be rendered between the header title a
 - set the title and taxonomies for each language;
 - add the `language_name.{code}` in `[extra]`. This is the text shown in the language switcher.
 
-See [these lines in the provided `config.toml`](https://github.com/welpo/tabi/blob/main/config.toml#L22-L132) for an example.
+See [these lines in the provided `config.toml`](https://github.com/welpo/tabi/blob/main/config.toml#L22-L134) for an example.
 
 You will need an `_index.{language_code}.md` per language for each section (e.g. /blog or /projects) that you want to enable in that language.
 

--- a/config.toml
+++ b/config.toml
@@ -72,6 +72,7 @@ show_original_quote = "Mostrar cita original"
 show_translation = "Mostrar traducción"
 load_comments = "Cargar comentarios"
 see_changes = "Ver cambios"
+site_source = "Código del sitio"
 # Quotation marks for multilingual quote shortcode.
 open_quotation_mark = "«"
 close_quotation_mark = "»"
@@ -117,6 +118,7 @@ show_original_quote = "Mostra la cita original"
 show_translation = "Mostra la traducció"
 load_comments = "Carregar comentaris"
 see_changes = "Veure canvis"
+site_source = "Codi del lloc"
 # Quotation marks for multilingual quote shortcode.
 open_quotation_mark = "«"
 close_quotation_mark = "»"
@@ -138,15 +140,18 @@ language_name.en = "English"
 language_name.es = "Español"
 
 # Remote repository for your Zola site.
-# Only used to link to the commit history of updated posts, right next to the updated date.
+# Used for `show_remote_changes` and `show_remote_source` (see below).
 # Supports GitHub, GitLab, Gitea, and Codeberg.
 remote_repository_url = "https://github.com/welpo/tabi"
 # Set this to "auto" to try and auto-detect the platform based on the repository URL.
 # Accepted values are "github", "gitlab", "gitea", and "codeberg".
-# Defaults to "auto".
-remote_repository_git_platform = "auto"
-# Branch in the repo hosting the Zola site. Defaults to "main".
-remote_repository_branch = "main"
+remote_repository_git_platform = "auto"  # Defaults to "auto".
+# Branch in the repo hosting the Zola site.
+remote_repository_branch = "main"  # Defaults to "main".
+# Show a link to the commit history of updated posts, right next to the last updated date.
+show_remote_changes = true  # Defaults to true.
+# Show a link to the repository of the site, right next to the "Powered by Zola & tabi" text.
+show_remote_source = true  # Defaults to true.
 
 # Enable JavaScript theme toggler to allow users to switch between dark/light mode.
 # Also enables automatic switching based on user's OS-level theme settings.

--- a/templates/macros/content.html
+++ b/templates/macros/content.html
@@ -32,7 +32,9 @@
 
             {% if page.updated %}
                 </ul><ul class="meta last-updated"><li>{%- if lang != config.default_language %} {{ trans(key="last_updated_on" | safe, lang=lang) }} {% else %} Last updated on {% endif %} {{ macros_format_date::format_date(date=page.updated, short=true) }}</li>
-                {% if config.extra.remote_repository_url %}
+                {# Show link to remote changes if enabled #}
+                {% set show_remote_changes = config.extra.show_remote_changes | default(value=true) %}
+                {% if config.extra.remote_repository_url and show_remote_changes %}
                     <li>&nbsp;{{ separator }}&nbsp;<a href="{{ macros_create_history_url::create_history_url(relative_path=page.relative_path) }}" target="_blank" rel="noopener noreferrer">{%- if lang != config.default_language -%}{{ trans(key="see_changes" | safe, lang=lang) }}{% else %}See changes{%- endif -%}<small> ↗</small></a></li>
                 {% endif %}
             {% endif %}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -1,3 +1,4 @@
+{% set separator = config.extra.separator | default(value="•") %}
 <footer>
     <section>
         <nav class="socials nav-navs">
@@ -49,7 +50,35 @@
             {% endif %}
         </nav>
         <div class="credits">
-            <small>{%- if lang != config.default_language %} {{ trans(key="powered_by" | safe, lang=lang) }} {% else %} Powered by {% endif %} <a href="https://www.getzola.org" target="_blank">Zola</a> {%- if lang != config.default_language %} {{ trans(key="and" | safe, lang=lang) }} {% else %} & {% endif %} <a href="https://github.com/welpo/tabi" target="_blank">tabi</a></small>
+            {# Shows "Powered by Zola & tabi" #}
+            {# Shows link to remote repository if repository is set and `show_remote_source` is not false #}
+            {% set show_source = config.extra.show_remote_source | default(value=true) %}
+            <small>
+                {%- if lang != config.default_language -%} 
+                    {{ trans(key="powered_by" | safe, lang=lang) }} 
+                {%- else -%} 
+                    Powered by
+                {%- endif -%} 
+                &nbsp;<a href="https://www.getzola.org" target="_blank">Zola</a>&nbsp;
+        
+                {%- if lang != config.default_language -%}
+                    {{ trans(key="and" | safe, lang=lang) }} 
+                {%- else -%} 
+                    &
+                {%- endif -%} 
+                &nbsp;<a href="https://github.com/welpo/tabi" target="_blank">tabi</a>
+
+                {%- if config.extra.remote_repository_url and show_source -%}
+                &nbsp;{{ separator }}
+                    <a href="{{ config.extra.remote_repository_url }}" target="_blank">
+                        {%- if lang != config.default_language -%}
+                            {{ trans(key="site_source" | safe, lang=lang) }}
+                        {%- else -%}
+                            Site source
+                        {%- endif -%}
+                    </a>
+                {%- endif -%}
+            </small>
         </div>
     </section>
 


### PR DESCRIPTION
<details>
  <summary><b>TL;DR</b></summary>
Enhanced the remote repository linking with a new feature (`show_remote_source`) and two configuration options (`show_remote_changes`, `show_remote_source`).
</details>

#### Description

This PR introduces one new feature and two new options to enhance the experience of users and provide better control over the display of remote repository links.

These options are only useful if the `remote_repository_url` is set.

1. **Show remote changes option (`show_remote_changes`)**:
    - A new configuration option that determines if a link to the commit history of updated posts should be displayed (expands on 109).
    - Defaults to `true`.

2. **Show remote source option (`show_remote_source`)**:
    - Another configuration option that decides if a link to the repository of the site should be shown, displayed next to the "Powered by Zola & tabi" text.
    - New feature.
    - Defaults to `true`.

#### Changes made

1. **TOML Configuration**:
    - Added `show_remote_changes` and `show_remote_source`.

2. **Tera Template**:
    - Integrated the new configuration options into the Tera template.
    - Ensured that the link to the site's repository is displayed conditionally based on the `show_remote_source` value.
    - Cleaned up `footer.hmtl` template formatting for better readability.

#### Screenshots

When `remote_repository_url` is set and `show_remote_source = true`:

![after](https://github.com/welpo/tabi/assets/6399341/4c510fd8-61c1-4e9f-9db1-43f27c973c2c)