### PR TITLE
✨ feat(footer): add configurable copyright notice

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -230,6 +230,15 @@ socials = [
     { name = "spotify", url = "https://open.spotify.com/artist/5Hv2bYBhMp1lUHFri06xkE", icon = "spotify" },
 ]
 
+# Enable a copyright notice for the footer, shown between socials and the "Powered by" text.
+# You can use $CURRENT_YEAR to automatically insert the current year.
+# Markdown is supported (links, emphasis, etc).
+# copyright = "© $CURRENT_YEAR Your Name • Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
+
+# For multi-language sites, you can set a different copyright for each language.
+# If this is set to true, ensure you have a `copyright` translation for each language.
+translate_copyright = false
+
 # Custom security headers. What urls should your website be able to connect to?
 # You need to specify the CSP and the URLs associated with the directive.
 # Useful if you want to load remote content safely (embed YouTube videos, which needs frame-src, for example).

--- a/sass/parts/_footer.scss
+++ b/sass/parts/_footer.scss
@@ -72,4 +72,9 @@ footer nav {
 .credits {
     font-size: 0.88rem;
     color: var(--meta-color);
+    text-align: center;
+
+    p {
+        margin: 0;
+    }
 }

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -50,17 +50,25 @@
             {% endif %}
         </nav>
         <div class="credits">
-            {# Shows "Powered by Zola & tabi" #}
-            {# Shows link to remote repository if repository is set and `show_remote_source` is not false #}
-            {% set show_source = config.extra.show_remote_source | default(value=true) %}
             <small>
+                {# Shows optional Copyright notice #}
+                {%- if config.extra.copyright -%}
+                    {% set current_year = now() | date(format="%Y") %}
+                    {# Translate the copyright if set in the config #}
+                    {%- if config.extra.translate_copyright and lang != config.default_language -%} 
+                        <p>{{ trans(key="copyright", lang=lang) | replace(from="$CURRENT_YEAR", to=current_year) | markdown | safe }}</p>
+                    {%- else -%}
+                        <p>{{ config.extra.copyright | replace(from="$CURRENT_YEAR", to=current_year) | markdown | safe }}</p>
+                    {%- endif -%}
+                {%- endif -%}
+
+                {# Shows "Powered by Zola & tabi" notice #}
                 {%- if lang != config.default_language -%} 
                     {{ trans(key="powered_by" | safe, lang=lang) }} 
                 {%- else -%} 
                     Powered by
                 {%- endif -%} 
                 &nbsp;<a href="https://www.getzola.org" target="_blank">Zola</a>&nbsp;
-        
                 {%- if lang != config.default_language -%}
                     {{ trans(key="and" | safe, lang=lang) }} 
                 {%- else -%} 
@@ -68,6 +76,8 @@
                 {%- endif -%} 
                 &nbsp;<a href="https://github.com/welpo/tabi" target="_blank">tabi</a>
 
+                {# Shows link to remote repository if repository is set and `show_remote_source` is not false #}
+                {% set show_source = config.extra.show_remote_source | default(value=true) %}
                 {%- if config.extra.remote_repository_url and show_source -%}
                 &nbsp;{{ separator }}
                     <a href="{{ config.extra.remote_repository_url }}" target="_blank">

--- a/theme.toml
+++ b/theme.toml
@@ -19,23 +19,24 @@ homepage = "https://osc.garden"
 # be merged with user data, some kind of prefix or nesting is preferable
 # Use snake_casing to be consistent with the rest of Zola
 [extra]
-# Languages of your site.
-# You'll need to add the language translations for each non-English language.
-# See the config.toml file for an example.
+
 language_name.ca = "Català"
 language_name.en = "English"
 language_name.es = "Español"
 
 # Remote repository for your Zola site.
-# Only used to link to the commit history of updated posts, right next to the updated date.
+# Used for `show_remote_changes` and `show_remote_source` (see below).
 # Supports GitHub, GitLab, Gitea, and Codeberg.
 remote_repository_url = "https://github.com/welpo/tabi"
 # Set this to "auto" to try and auto-detect the platform based on the repository URL.
 # Accepted values are "github", "gitlab", "gitea", and "codeberg".
-# Defaults to "auto".
-remote_repository_git_platform = "auto"
-# Branch in the repo hosting the Zola site. Defaults to "main".
-remote_repository_branch = "main"
+remote_repository_git_platform = "auto"  # Defaults to "auto".
+# Branch in the repo hosting the Zola site.
+remote_repository_branch = "main"  # Defaults to "main".
+# Show a link to the commit history of updated posts, right next to the last updated date.
+show_remote_changes = true  # Defaults to true.
+# Show a link to the repository of the site, right next to the "Powered by Zola & tabi" text.
+show_remote_source = true  # Defaults to true.
 
 # Enable JavaScript theme toggler to allow users to switch between dark/light mode.
 # Also enables automatic switching based on user's OS-level theme settings.
@@ -97,6 +98,14 @@ menu = [
 # The RSS icon will be shown if (1) it's enabled and (2) the following variable is set to true.
 feed_icon = true
 
+# Email address for footer's social section.
+# Protect against spambots:
+# 1. Use base64 for email (convert at https://www.base64encode.org/ or `printf 'your@email.com' | base64`).
+# 2. Or, set 'encode_plaintext_email' to true for auto-encoding (only protects on site, not in public repos).
+email = "bWFpbEBleGFtcGxlLmNvbQ=="  # base64 encoded version of "mail@example.com"
+# Decoding requires ~400 bytes of JavaScript. If JS is disabled, the email won't be displayed.
+encode_plaintext_email = true  # Setting is ignored if email is already encoded.
+
 # The icons available can be found in "social_icons" in the "static" folder.
 socials = [
     { name = "github", url = "https://github.com/welpo/", icon = "github" },
@@ -105,6 +114,15 @@ socials = [
     { name = "youtube", url = "https://youtube.com/@oskerwyld", icon = "youtube" },
     { name = "spotify", url = "https://open.spotify.com/artist/5Hv2bYBhMp1lUHFri06xkE", icon = "spotify" },
 ]
+
+# Enable a copyright notice for the footer, shown between socials and the "Powered by" text.
+# You can use $CURRENT_YEAR to automatically insert the current year.
+# Markdown is supported (links, emphasis, etc).
+# copyright = "© $CURRENT_YEAR Your Name • Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
+
+# For multi-language sites, you can set a different copyright for each language.
+# If this is set to true, ensure you have a `copyright` translation for each language.
+translate_copyright = false
 
 # Custom security headers. What urls should your website be able to connect to?
 # You need to specify the CSP and the URLs associated with the directive.


### PR DESCRIPTION
<details>
  <summary><b>TL;DR</b></summary>
Add a dynamic and translatable copyright notice for the footer.
</details>

### Description

This PR adds a feature that allows users to add a custom copyright notice in the footer of their site.

**Key features**:

1. **Dynamic year insertion**:
    - Users can use the `$CURRENT_YEAR` placeholder to automatically have the current year inserted into the copyright notice, eliminating the need to manually update it each year.

2. **Markdown support**:
    - Enhanced the notice with Markdown support, letting users easily add links, emphasize text, or make other necessary formatting changes.

3. **Multi-language support**:
    - For sites in multiple languages, there's an option to set a translated version of the copyright.

---

#### Changes

1. **TOML configuration**:
    - Added `copyright` and `translate_copyright` options.
    - Provided comments explaining the purpose and usage of each option.

2. **Tera template**:
    - Updated the footer template to include the new copyright feature.
    - Ensured that the translated version is used based on site's language configuration and user preference.

3. **Footer CSS**:
    - Centered the footer text and removed the margin between paragraphs.

---

#### Screenshots:

- A simple notice:

    ```toml
    [extra]
    copyright = "© $CURRENT_YEAR welpo
    ```

    ![simple](https://github.com/welpo/tabi/assets/6399341/d7314ac4-4501-4ec3-9db0-3458a5bcc239)

- A more complex notice, with Markdown:

    ```toml
    [extra]
    copyright = "© $CURRENT_YEAR Your Name • Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
    ```

    ![complex](https://github.com/welpo/tabi/assets/6399341/cc1604ad-56fd-4581-9866-cb42bb9666d9)