### PR TITLE
✨feat(config): add dynamic stylesheet loading via config.toml and page Metadata

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -176,6 +176,12 @@ default_theme = "light"
 # All other skins have optimal contrast.
 skin = ""
 
+# List additional stylesheets to load site-wide.
+# These stylesheets should be located in your site's `static` directory.
+# Example: stylesheets = ["extra1.css", "path/extra2.css"]
+# You can load a stylesheet for a single post by adding it to the [extra] section of the post's front matter, following this same format.
+stylesheets = []
+
 # Add a "copy" button to codeblocks (loads ~700 bytes of JavaScript).
 copy_button = true
 

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -28,13 +28,29 @@
         <link rel="stylesheet" href={{ get_url(path="inter_subset_es.css" ) }}>
     {% endif %}
 
-    <link rel="stylesheet" type="text/css" media="screen" href={{ get_url(path="main.css", cachebust=true ) }} />
+    {# Define array of CSS files to load. main.css is always loaded. #}
+    {%- set stylesheets = [ "main.css" ] -%}
+
+    {# Load extra CSS files from config.toml #}
+    {%- if config.extra.stylesheets -%}
+        {%- set stylesheets = stylesheets | concat(with=config.extra.stylesheets) -%}
+    {%- endif -%}
+
+    {# Load extra CSS files from page metadata #}
+    {%- if page.extra.stylesheets -%}
+        {%- set stylesheets = stylesheets | concat(with=page.extra.stylesheets) -%}
+    {%- endif -%}
 
     {# Load extra CSS for custom skin #}
     {%- if config.extra.skin and config.extra.skin != "teal" -%}
-        <link rel="stylesheet" href="{{ get_url(path='skins/' ~ config.extra.skin ~ '.css', cachebust=true) | safe }}" />
+        {%- set stylesheets = stylesheets | concat(with='skins/' ~ config.extra.skin ~ '.css') -%}
     {%- endif -%}
 
+    {# Load all stylesheets #}
+    {%- for stylesheet in stylesheets %}
+        <link rel="stylesheet" href="{{ get_url(path=stylesheet, cachebust=true) | safe }}" />
+    {%- endfor %}
+    
     <meta name="color-scheme" content="{%- if config.extra.theme_switcher -%}light dark{%- elif config.extra.default_theme -%}{{config.extra.default_theme}}{%- else -%}light{%- endif -%}">
 
     {%- if page.description %}

--- a/theme.toml
+++ b/theme.toml
@@ -61,6 +61,12 @@ default_theme = "light"
 # All other skins have optimal contrast.
 skin = ""
 
+# List additional stylesheets to load site-wide.
+# These stylesheets should be located in your site's `static` directory.
+# Example: stylesheets = ["extra1.css", "path/extra2.css"]
+# You can load a stylesheet for a single post by adding it to the [extra] section of the post's front matter, following this same format.
+stylesheets = []
+
 # Add a "copy" button to codeblocks (loads ~700 bytes of JavaScript).
 copy_button = true
 


### PR DESCRIPTION
### Description

This PR addresses issue #117. It adds a new feature that allows users to specify additional stylesheets in the `config.toml` and individual page metadata. This functionality adds flexibility for custom themes and individual post styling.

PR #105 removed a simpler (and undocumented) implementation of this feature.

### Changes

- Implemented dynamic stylesheet loading in the `header.html` template.
- Added `stylesheets` field to `config.toml` and `theme.toml`.
- Updated documentation in the configuration files to guide users on using the new feature.
  
### How to use:

1. Specify additional stylesheets in `config.toml` under `stylesheets` as an array. For a single file there's no need for an array.
    ```toml
    [extra]
    stylesheets = ["extra1.css", "path/extra2.css"]
    ```
   
2. For individual pages, add stylesheets to the `[extra]` section in the front matter.
    ```markdown
    +++
    title = "My Page"
    [extra]
    stylesheets = "individual.css"  # Use an array for more than one file.
    +++
    ```

**Note**: Since Zola processes `.sass` and `.scss` files in the `sass` folder into `.css` files in the `public` folder (see [Zola docs](https://www.getzola.org/documentation/content/sass/)), you should specify the processed `.css` filenames in the `stylesheets` field.

For example, if you have a `.scss` file located at `sass/extra.scss`, Zola will render it into `public/extra.css`. You should then specify `extra.css` in the `stylesheets` field like so:

```toml
[extra]
stylesheets = ["extra.css"]
```