### PR TITLE
README: Add link to table of contents documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ tabi has a perfect score on Google's Lighthouse audit:
 - [X] [Stylized feed](https://welpo.github.io/tabi/atom.xml).
 - [X] [Projects page](https://welpo.github.io/tabi/projects/).
 - [X] [Archive page](https://welpo.github.io/tabi/archive/).
+- [x] [Table of Contents](https://welpo.github.io/tabi/blog/toc/).
 - [x] Tags.
 - [x] Social links.
 - [X] Responsive design.


### PR DESCRIPTION
I think this closes https://github.com/welpo/tabi/issues/120.