### PR TITLE
Support hiding the read time indication on pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -186,6 +186,7 @@ stylesheets = []
 copy_button = true
 
 # Show the reading time of a page.
+# Can also be enabled or disabled on individual pages in the front matter's [extra].
 show_reading_time = true
 
 # Adds backlinks to footnotes (loads ~500 bytes of JavaScripts).

--- a/config.toml
+++ b/config.toml
@@ -185,6 +185,9 @@ stylesheets = []
 # Add a "copy" button to codeblocks (loads ~700 bytes of JavaScript).
 copy_button = true
 
+# Show the reading time of a page.
+show_reading_time = true
+
 # Adds backlinks to footnotes (loads ~500 bytes of JavaScripts).
 footnote_backlinks = false
 

--- a/templates/macros/content.html
+++ b/templates/macros/content.html
@@ -14,11 +14,12 @@
             {% endif %}
 
             {% if page.date %}
-                <li>{{ macros_format_date::format_date(date=page.date, short=true) }} {{ separator }}</li>
+                <li>{{ macros_format_date::format_date(date=page.date, short=true) }}</li>
             {% endif %}
 
-            {% if page.extra.show_reading_time %}
-                <li title="{{ page.word_count }} {%- if lang != config.default_language %} {{ trans(key="words" | safe, lang=lang) }} {% else %} words {% endif %}">&nbsp;{{ page.reading_time }}{%- if lang != config.default_language %} {{ trans(key="min_read" | safe, lang=lang) }} {% else %} min read {% endif %}</li>
+            {# page settings override config settings #}
+            {% if page.extra.show_reading_time | default(value="") == true or page.extra.show_reading_time | default(value="") != false and config.extra.show_reading_time | default(value=true) %}
+                {{ separator }} <li title="{{ page.word_count }} {%- if lang != config.default_language %} {{ trans(key="words" | safe, lang=lang) }} {% else %} words {% endif %}">{{ page.reading_time }}{%- if lang != config.default_language %} {{ trans(key="min_read" | safe, lang=lang) }} {% else %} min read {% endif %}</li>
             {% endif %}
 
             {% if page.taxonomies and page.taxonomies.tags %}

--- a/templates/macros/content.html
+++ b/templates/macros/content.html
@@ -17,7 +17,9 @@
                 <li>{{ macros_format_date::format_date(date=page.date, short=true) }} {{ separator }}</li>
             {% endif %}
 
-            <li title="{{ page.word_count }} {%- if lang != config.default_language %} {{ trans(key="words" | safe, lang=lang) }} {% else %} words {% endif %}">&nbsp;{{ page.reading_time }}{%- if lang != config.default_language %} {{ trans(key="min_read" | safe, lang=lang) }} {% else %} min read {% endif %}</li>
+            {% if !page.extra.skip_readtime %}
+                <li title="{{ page.word_count }} {%- if lang != config.default_language %} {{ trans(key="words" | safe, lang=lang) }} {% else %} words {% endif %}">&nbsp;{{ page.reading_time }}{%- if lang != config.default_language %} {{ trans(key="min_read" | safe, lang=lang) }} {% else %} min read {% endif %}</li>
+            {% endif %}
 
             {% if page.taxonomies and page.taxonomies.tags %}
                 <li>&nbsp;{{ separator }}&nbsp;{%- if lang != config.default_language -%}{{ trans(key="tags" | safe, lang=lang) | capitalize }}{% else %}Tags{%- endif -%}:&nbsp;</li>

--- a/templates/macros/content.html
+++ b/templates/macros/content.html
@@ -17,7 +17,7 @@
                 <li>{{ macros_format_date::format_date(date=page.date, short=true) }} {{ separator }}</li>
             {% endif %}
 
-            {% if !page.extra.skip_readtime %}
+            {% if page.extra.show_reading_time %}
                 <li title="{{ page.word_count }} {%- if lang != config.default_language %} {{ trans(key="words" | safe, lang=lang) }} {% else %} words {% endif %}">&nbsp;{{ page.reading_time }}{%- if lang != config.default_language %} {{ trans(key="min_read" | safe, lang=lang) }} {% else %} min read {% endif %}</li>
             {% endif %}
 

--- a/theme.toml
+++ b/theme.toml
@@ -70,6 +70,10 @@ stylesheets = []
 # Add a "copy" button to codeblocks (loads ~700 bytes of JavaScript).
 copy_button = true
 
+# Show the reading time of a page.
+# Can also be enabled or disabled on individual pages in the front matter's [extra].
+show_reading_time = true
+
 # Adds backlinks to footnotes (loads ~500 bytes of JavaScripts).
 footnote_backlinks = false
 


### PR DESCRIPTION
I'm not sure if there is some kind of documentation on all extra fields that exist. I think there really should be. If there is, let me know where, so I can add this one as part of this MR. Or merge it and add it yourself :) Or reject it ofc :)