### PR TITLE
✨ feat(HTML): introduce rel attribute macro and remove hardcoded values

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,14 +1,15 @@
-{% import "macros/list_posts.html" as macros_list_posts %}
-{% import "macros/page_header.html" as macros_page_header %}
-{% import "macros/page_desc.html" as macros_page_desc %}
-{% import "macros/content.html" as macros_content %}
-{% import "macros/cards_pages.html" as macros_cards_pages %}
-{% import "macros/set_title.html" as macros_set_title %}
-{% import "macros/paginate.html" as macros_paginate %}
-{% import "macros/format_date.html" as macros_format_date %}
 {% import "macros/add_comments.html" as macros_add_comments %}
-{% import "macros/table_of_contents.html" as macros_toc %}
+{% import "macros/cards_pages.html" as macros_cards_pages %}
+{% import "macros/content.html" as macros_content %}
 {% import "macros/create_history_url.html" as macros_create_history_url %}
+{% import "macros/format_date.html" as macros_format_date %}
+{% import "macros/list_posts.html" as macros_list_posts %}
+{% import "macros/page_desc.html" as macros_page_desc %}
+{% import "macros/page_header.html" as macros_page_header %}
+{% import "macros/paginate.html" as macros_paginate %}
+{% import "macros/rel_attributes.html" as macros_rel_attributes %}
+{% import "macros/set_title.html" as macros_set_title %}
+{% import "macros/table_of_contents.html" as macros_toc %}
 
 <!DOCTYPE html>
 <html lang="{{ lang }}" {% if config.extra.default_theme -%}

--- a/templates/macros/cards_pages.html
+++ b/templates/macros/cards_pages.html
@@ -1,10 +1,18 @@
 {% macro cards_pages(pages) %}
 
+{%- set rel_attributes = macros_rel_attributes::rel_attributes() | trim -%}
+
+{%- if config.markdown.external_links_target_blank -%}
+    {%- set blank_target = "target=_blank" -%}
+{%- else -%}
+    {%- set blank_target = "" -%}
+{%- endif -%}
+
 <div class="cards">
     {%- for page in pages %}
     <div class="card">
         {% if page.extra.link_to %}
-            <a rel="noopener noreferrer" target="_blank" href={{ page.extra.link_to }}>
+            <a rel="{{ rel_attributes }}" {{ blank_target }} href={{ page.extra.link_to }}>
         {% endif %}
         {% if page.extra.local_image %}
             {% set meta = get_image_metadata(path=page.extra.local_image, allow_missing=true) %}
@@ -21,7 +29,7 @@
         <div class="card-info">
             <h1 class="card-title">
                 {% if page.extra.link_to %}
-                    <a rel="noopener noreferrer" target="_blank" href={{ page.extra.link_to }}>{{page.title}}</a>
+                    <a rel="{{ rel_attributes }}" {{ blank_target }} href={{ page.extra.link_to }}>{{page.title}}</a>
                 {% else %}
                     <a href={{ page.permalink }}>{{page.title}}</a>
                 {% endif %}

--- a/templates/macros/content.html
+++ b/templates/macros/content.html
@@ -1,6 +1,14 @@
 {% macro content(page) %}
 
-{% set separator = config.extra.separator | default(value="•") %}
+{%- set separator = config.extra.separator | default(value="•") -%}
+
+{%- set rel_attributes = macros_rel_attributes::rel_attributes() | trim -%}
+
+{%- if config.markdown.external_links_target_blank -%}
+    {%- set blank_target = "target=_blank" -%}
+{%- else -%}
+    {%- set blank_target = "" -%}
+{%- endif -%}
 
 <main>
     <article>
@@ -35,7 +43,7 @@
                 {# Show link to remote changes if enabled #}
                 {% set show_remote_changes = config.extra.show_remote_changes | default(value=true) %}
                 {% if config.extra.remote_repository_url and show_remote_changes %}
-                    <li>&nbsp;{{ separator }}&nbsp;<a href="{{ macros_create_history_url::create_history_url(relative_path=page.relative_path) }}" target="_blank" rel="noopener noreferrer">{%- if lang != config.default_language -%}{{ trans(key="see_changes" | safe, lang=lang) }}{% else %}See changes{%- endif -%}<small> ↗</small></a></li>
+                    <li>&nbsp;{{ separator }}&nbsp;<a href="{{ macros_create_history_url::create_history_url(relative_path=page.relative_path) }}" {{ blank_target }} rel="{{ rel_attributes }}">{%- if lang != config.default_language -%}{{ trans(key="see_changes" | safe, lang=lang) }}{% else %}See changes{%- endif -%}<small> ↗</small></a></li>
                 {% endif %}
             {% endif %}
         </ul>

--- a/templates/macros/rel_attributes.html
+++ b/templates/macros/rel_attributes.html
@@ -1,0 +1,19 @@
+{% macro rel_attributes() %}
+
+{%- set rel_attributes = [] -%}
+{%- if config.markdown.external_links_target_blank -%}
+    {%- set rel_attributes = rel_attributes | concat(with="noopener")  -%}
+{%- endif -%}
+{# https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#nofollow #}
+{# This is ignored, as it doesn't make sense to set `nofollow` on projects or social links. #}
+{# {%- if config.markdown.external_links_no_follow -%}
+    {%- set rel_attributes = rel_attributes | concat(with="nofollow")  -%}
+{%- endif -%} #}
+{%- if config.markdown.external_links_no_referrer -%}
+    {%- set rel_attributes = rel_attributes | concat(with="noreferrer")  -%}
+{%- endif -%}
+
+{# Return the array of rel attributes joined by a space #}
+{{- rel_attributes | join(sep=" ") -}}
+
+{% endmacro external_links %}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -1,4 +1,13 @@
-{% set separator = config.extra.separator | default(value="•") %}
+{%- set separator = config.extra.separator | default(value="•") -%}
+
+{%- set rel_attributes = macros_rel_attributes::rel_attributes() | trim -%}
+
+{%- if config.markdown.external_links_target_blank -%}
+    {%- set blank_target = "target=_blank" -%}
+{%- else -%}
+    {%- set blank_target = "" -%}
+{%- endif -%}
+
 <footer>
     <section>
         <nav class="socials nav-navs">
@@ -6,7 +15,7 @@
                 <ul>
                     {%- if config.generate_feed and config.extra.feed_icon -%}
                     <li>
-                        <a rel="noopener noreferrer" target="_blank" class="nav-links no-hover-padding social" href={{ get_url(path=config.feed_filename, lang=lang, trailing_slash=false) | safe }}>
+                        <a class="nav-links no-hover-padding social" rel="{{ rel_attributes }}" {{ blank_target }} href={{ get_url(path=config.feed_filename, lang=lang, trailing_slash=false) | safe }}>
                         <img alt="feed" title="feed" src="{{ get_url(path='/social_icons/rss.svg') }}">
                         </a>
                     </li>
@@ -30,9 +39,9 @@
 
                         <li class="{% if email_needs_decoding %}js{% endif %}">
                             {%- if email_needs_decoding -%}
-                                <a rel="noopener noreferrer" target="_blank" class="nav-links no-hover-padding social" href="#" data-encoded-email="{{ encoded_email | safe }}">
+                                <a class="nav-links no-hover-padding social" href="#" data-encoded-email="{{ encoded_email | safe }}">
                             {%- else -%}
-                                <a rel="noopener noreferrer" target="_blank" class="nav-links no-hover-padding social" href="mailto:{{ config.extra.email | safe }}">
+                                <a class="nav-links no-hover-padding social" href="mailto:{{ config.extra.email | safe }}">
                             {%- endif -%}
                                 <img alt="email" title="email" src="{{ get_url(path='social_icons/email.svg') }}">
                             </a>
@@ -41,7 +50,7 @@
 
                     {% for social in config.extra.socials %}
                         <li>
-                            <a rel="noopener noreferrer me" target="_blank" class="nav-links no-hover-padding social" href={{ social.url | safe }}>
+                            <a class="nav-links no-hover-padding social" rel="{{ rel_attributes }} me" {{ blank_target }} href={{ social.url | safe }}>
                                 <img alt={{ social.name }} title={{ social.name }} src="{{ get_url(path='social_icons/' ~ social.icon ~ '.svg') }}">
                             </a>
                         </li>
@@ -68,19 +77,19 @@
                 {%- else -%} 
                     Powered by
                 {%- endif -%} 
-                &nbsp;<a href="https://www.getzola.org" target="_blank">Zola</a>&nbsp;
+                &nbsp;<a rel="{{ rel_attributes }}" {{ blank_target }} href="https://www.getzola.org">Zola</a>&nbsp;
                 {%- if lang != config.default_language -%}
                     {{ trans(key="and" | safe, lang=lang) }} 
                 {%- else -%} 
                     &
                 {%- endif -%} 
-                &nbsp;<a href="https://github.com/welpo/tabi" target="_blank">tabi</a>
+                &nbsp;<a rel="{{ rel_attributes }}" {{ blank_target }} href="https://github.com/welpo/tabi">tabi</a>
 
                 {# Shows link to remote repository if repository is set and `show_remote_source` is not false #}
                 {% set show_source = config.extra.show_remote_source | default(value=true) %}
                 {%- if config.extra.remote_repository_url and show_source -%}
                 {{ separator }}
-                    <a href="{{ config.extra.remote_repository_url }}" target="_blank">
+                    <a rel="{{ rel_attributes }}" {{ blank_target }} href="{{ config.extra.remote_repository_url }}">
                         {%- if lang != config.default_language -%}
                             {{ trans(key="site_source" | safe, lang=lang) }}
                         {%- else -%}


### PR DESCRIPTION
#### Summary
This PR introduces a new HTML macro to assemble `rel` attributes dynamically based on config values. It also removes all hardcoded `noopener`, `noreferrer`, and `target=_blank` values from the project.

### Description:
This PR introduces a macro to assemble `rel` attributes dynamically based on config values, eliminating all hardcoded `noopener`, `noreferrer`, and `target=_blank` values.

### Changes:
- Removed hardcoded `noopener`, `noreferrer`, and `target=_blank` from HTML templates.
- Created a macro for assembling `rel` attributes based on config values.
- Sorted imports in `base.html`.