### PR TITLE
🔧 refactor(theme.toml) set sane defaults

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,13 +11,13 @@
 # Compresses PNG files with either oxipng or optipng if available.              #
 # Runs subset_font if config.toml has been modified.                            #
 # Updates the README if the line numbers for the language section have changed. #
-# Syncs the [extra] section from config.toml to theme.toml.                     #
 #                                                                               #
 # Stops you from commiting:                                                     #
 # - a draft .md file                                                            #
 # - a file with a "TODO"                                                        #
 # - a JS file without a minified version                                        #
 # - a minified JS file that isn't as small as it can be                         #
+# - a config.toml and theme.toml with different amounts of lines in [extra]     #
 #################################################################################
 
 # Function to exit the script with an error message.
@@ -77,7 +77,6 @@ function is_minified() {
     fi
 }
 
-
 # Check if the script is being run from the root of the repo.
 if [[ ! $(git rev-parse --show-toplevel) == $(pwd) ]]; then
     error_exit "This script must be run from the root of the repo."
@@ -103,6 +102,11 @@ all_changed_files=$(git diff --cached --name-only --diff-filter=AM)
 
 # Loop through all newly added or modified files.
 for file in $all_changed_files; do
+    # Ignore this script.
+    if [[ "$file" == "$0" ]]; then
+        continue
+    fi
+
     # If the file is a PNG and png_compressor is set, compress it and add it to the commit.
     if [[ "$file" == *.png ]] && [[ -n "$png_compressor" ]]; then
         $png_compressor "$file" || error_exit "Failed to compress PNG file $file"
@@ -133,25 +137,24 @@ for file in $all_changed_files; do
         is_minified "$file"
     fi
 
-    # Sync the [extra] section from config.toml to theme.toml.
-    # Check if config.toml has been modified; use spaces to avoid matching a substring.
-    if [[ "$file" == "config.toml" ]]; then
+    # Ensure the [extra] section from config.toml and theme.toml have the same amount of lines.
+    if [[ "$file" == "config.toml" ]] || [[ "$file" == "theme.toml" ]]; then
         # Get the line number where [extra] starts in config.toml.
-        config_extra_line=$(grep -n "^\[extra\]$" "config.toml" | cut -d: -f1)
-
-        # Extract content after [extra] from config.toml.
-        config_extra_content=$(tail -n +"$config_extra_line" "config.toml")
+        extra_line_config=$(grep -n "^\[extra\]$" "config.toml" | cut -d: -f1)
 
         # Get the line number where [extra] starts in theme.toml.
-        theme_extra_line=$(grep -n "^\[extra\]$" "theme.toml" | cut -d: -f1)
+        extra_line_theme=$(grep -n "^\[extra\]$" "theme.toml" | cut -d: -f1)
 
-        # Replace content after [extra] in theme.toml with extracted content from config.toml.
-        awk -v n="$theme_extra_line" 'NR<n' theme.toml > theme.tmp
-        echo "$config_extra_content" >> theme.tmp
-        mv theme.tmp theme.toml
+        # Get the number of lines in the [extra] section in config.toml.
+        extra_lines_config=$(tail -n +"$extra_line_config" "config.toml" | wc -l)
 
-        # Add theme.toml to the list of files to be committed.
-        git add "theme.toml"
+        # Get the number of lines in the [extra] section in theme.toml.
+        extra_lines_theme=$(tail -n +"$extra_line_theme" "theme.toml" | wc -l)
+
+        # Abort the commit if the number of lines in the [extra] section don't match.
+        if [[ "$extra_lines_config" -ne "$extra_lines_theme" ]]; then
+            error_exit "The [extra] section in config.toml and theme.toml don't have the same amount of lines!"
+        fi
     fi
 done
 

--- a/theme.toml
+++ b/theme.toml
@@ -23,14 +23,14 @@ homepage = "https://osc.garden"
 # Languages for your site.
 # Each should have a translation section above.
 # e.g. [languages.ca.translations]
-language_name.ca = "Català"
-language_name.en = "English"
-language_name.es = "Español"
+# language_name.ca = "Català"
+# language_name.en = "English"
+# language_name.es = "Español"
 
 # Remote repository for your Zola site.
 # Used for `show_remote_changes` and `show_remote_source` (see below).
 # Supports GitHub, GitLab, Gitea, and Codeberg.
-remote_repository_url = "https://github.com/welpo/tabi"
+# remote_repository_url = "https://github.com/welpo/tabi"
 # Set this to "auto" to try and auto-detect the platform based on the repository URL.
 # Accepted values are "github", "gitlab", "gitea", and "codeberg".
 remote_repository_git_platform = "auto"  # Defaults to "auto".
@@ -78,7 +78,7 @@ katex = false
 
 # Date format used when listing posts (main page, /blog section, tag posts list…)
 # Default is "6th July 2049" in English and "%d %B %Y" in other languages.
-long_date_format = "%d %B %Y"
+# long_date_format = "%d %B %Y"
 
 # Date format used for blog posts.
 # Default is "6th July 2049" in English and "%-d %B %Y" in other languages.
@@ -88,14 +88,14 @@ short_date_format = ""
 separator = "•"
 
 # Full path after the base URL required. So if you were to place it in "static" it would be "/favicon.ico"
-favicon = ""
+# favicon = ""
 
 # Add an emoji here to use it as favicon.
 # Compatibility: https://caniuse.com/link-icon-svg
-favicon_emoji = "🌱"
+# favicon_emoji = "🌱"
 
 # This header image is used for SEO. For example if you were to share an image via Messenger/Instagram/Twitter a preview picture is also presented
-headerImage = ""
+# headerImage = ""
 
 menu = [
     { name = "blog", url = "blog", trailing_slash = true },
@@ -111,18 +111,18 @@ feed_icon = true
 # Protect against spambots:
 # 1. Use base64 for email (convert at https://www.base64encode.org/ or `printf 'your@email.com' | base64`).
 # 2. Or, set 'encode_plaintext_email' to true for auto-encoding (only protects on site, not in public repos).
-email = "bWFpbEBleGFtcGxlLmNvbQ=="  # base64 encoded version of "mail@example.com"
+# email = "bWFpbEBleGFtcGxlLmNvbQ=="  # base64 encoded version of "mail@example.com"
 # Decoding requires ~400 bytes of JavaScript. If JS is disabled, the email won't be displayed.
 encode_plaintext_email = true  # Setting is ignored if email is already encoded.
 
 # The icons available can be found in "social_icons" in the "static" folder.
-socials = [
-    { name = "github", url = "https://github.com/welpo/", icon = "github" },
-    { name = "soundcloud", url = "https://soundcloud.com/oskerwyld", icon = "soundcloud" },
-    { name = "instagram", url = "https://instagram.com/oskerwyld", icon = "instagram" },
-    { name = "youtube", url = "https://youtube.com/@oskerwyld", icon = "youtube" },
-    { name = "spotify", url = "https://open.spotify.com/artist/5Hv2bYBhMp1lUHFri06xkE", icon = "spotify" },
-]
+# socials = [
+#     { name = "github", url = "https://github.com/welpo/", icon = "github" },
+#     { name = "soundcloud", url = "https://soundcloud.com/oskerwyld", icon = "soundcloud" },
+#     { name = "instagram", url = "https://instagram.com/oskerwyld", icon = "instagram" },
+#     { name = "youtube", url = "https://youtube.com/@oskerwyld", icon = "youtube" },
+#     { name = "spotify", url = "https://open.spotify.com/artist/5Hv2bYBhMp1lUHFri06xkE", icon = "spotify" },
+# ]
 
 # Enable a copyright notice for the footer, shown between socials and the "Powered by" text.
 # You can use $CURRENT_YEAR to automatically insert the current year.
@@ -152,65 +152,65 @@ allowed_domains = [
 # If set to true, the `static/custom_subset.css` file will be loaded first.
 # This avoids a flashing text issue in Firefox.
 # Please see https://welpo.github.io/tabi/blog/custom-font-subset/ to learn how to create this file.
-custom_subset = true
+# custom_subset = true
 
 # Quick navigation buttons.
 # Adds "go up" and "go to comments" buttons on the bottom right (hidden for mobile).
 # Can also be enabled on individual posts in the front matter's [extra].
-quick_navigation_buttons = false
+# quick_navigation_buttons = true
 
 # giscus support for comments. https://giscus.app
 # Setup instructions: https://welpo.github.io/tabi/blog/comments/#setup
 [extra.giscus]
-enabled_for_all_posts = false  # Enables giscus on all posts. It can be enabled on individual posts by setting `giscus = true` in the [extra] section of a post's front matter.
-automatic_loading = true  # If set to false, a "Load comments" button will be shown.
-repo = "welpo/tabi-comments"
-repo_id = "R_kgDOJ59Urw"  # Find this value in https://giscus.app/
-category = "Announcements"
-category_id = "DIC_kwDOJ59Ur84CX0QG"  # Find this value in https://giscus.app/
-mapping = "slug"  # Available: pathname; url; title; slug. "slug" will use the post's filename (slug); this is the only way to share comments between languages.
-strict_title_matching = 1  # 1 to enable, 0 to disable. https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md#data-strict
-enable_reactions = 1  # 1 to enable, 0 to disable.
-comment_box_above_comments = false
-light_theme = "noborder_light"
-dark_theme = "noborder_dark"
-lang = ""  # Leave blank to match the page's language.
-lazy_loading = true
+# enabled_for_all_posts = false  # Enables giscus on all posts. It can be enabled on individual posts by setting `giscus = true` in the [extra] section of a post's front matter.
+# automatic_loading = true  # If set to false, a "Load comments" button will be shown.
+# repo = "welpo/tabi-comments"
+# repo_id = "R_kgDOJ59Urw"  # Find this value in https://giscus.app/
+# category = "Announcements"
+# category_id = "DIC_kwDOJ59Ur84CX0QG"  # Find this value in https://giscus.app/
+# mapping = "slug"  # Available: pathname; url; title; slug. "slug" will use the post's filename (slug); this is the only way to share comments between languages.
+# strict_title_matching = 1  # 1 to enable, 0 to disable. https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md#data-strict
+# enable_reactions = 1  # 1 to enable, 0 to disable.
+# comment_box_above_comments = false
+# light_theme = "noborder_light"
+# dark_theme = "noborder_dark"
+# lang = ""  # Leave blank to match the page's language.
+# lazy_loading = true
 
 # utterances support for comments. https://utteranc.es
 # Setup instructions: https://welpo.github.io/tabi/blog/comments/#setup
 [extra.utterances]
-enabled_for_all_posts = false  # Enables utterances on all posts. It can be enabled on individual posts by setting `utterances = true` in the [extra] section of a post's front matter.
-automatic_loading = true  # If set to false, a "Load comments" button will be shown.
-repo = "yourGithubUsername/yourRepo"  # https://utteranc.es/#heading-repository
-issue_term = "slug"  # Available: pathname; url; title; slug. "slug" will use the post's filename (slug); this is the only way to share comments between languages. https://utteranc.es/#heading-mapping
-label = "💬"  # https://utteranc.es/#heading-issue-label
-light_theme = "github-light"  # https://utteranc.es/#heading-theme
-dark_theme = "photon-dark"  # https://utteranc.es/#heading-theme
-lazy_loading = true
+# enabled_for_all_posts = false  # Enables utterances on all posts. It can be enabled on individual posts by setting `utterances = true` in the [extra] section of a post's front matter.
+# automatic_loading = true  # If set to false, a "Load comments" button will be shown.
+# repo = "yourGithubUsername/yourRepo"  # https://utteranc.es/#heading-repository
+# issue_term = "slug"  # Available: pathname; url; title; slug. "slug" will use the post's filename (slug); this is the only way to share comments between languages. https://utteranc.es/#heading-mapping
+# label = "💬"  # https://utteranc.es/#heading-issue-label
+# light_theme = "github-light"  # https://utteranc.es/#heading-theme
+# dark_theme = "photon-dark"  # https://utteranc.es/#heading-theme
+# lazy_loading = true
 
 # Hyvor Talk support for comments. https://talk.hyvor.com
 [extra.hyvortalk]
-enabled_for_all_posts = false  # Enables hyvortalk on all posts. It can be enabled on individual posts by setting `hyvortalk = true` in the [extra] section of a post's front matter.
-automatic_loading = true  # If set to false, a "Load comments" button will be shown.
-website_id = "1234"
-page_id_is_slug = true  # If true, it will use the post's filename (slug) as id; this is the only way to share comments between languages. If false, it will use the entire url as id.
-lang = ""  # Leave blank to match the page's language.
-page_author = ""  # Email (or base64 encoded email) of the author.
-lazy_loading = true
+# enabled_for_all_posts = false  # Enables hyvortalk on all posts. It can be enabled on individual posts by setting `hyvortalk = true` in the [extra] section of a post's front matter.
+# automatic_loading = true  # If set to false, a "Load comments" button will be shown.
+# website_id = "1234"
+# page_id_is_slug = true  # If true, it will use the post's filename (slug) as id; this is the only way to share comments between languages. If false, it will use the entire url as id.
+# lang = ""  # Leave blank to match the page's language.
+# page_author = ""  # Email (or base64 encoded email) of the author.
+# lazy_loading = true
 
 # Isso support for comments. https://isso-comments.de/
 # You need to self-host the backend first: https://blog.phusion.nl/2018/08/16/isso-simple-self-hosted-commenting-system/
 # More info on some settings: https://isso-comments.de/docs/reference/client-config/
 [extra.isso]
-enabled_for_all_posts = false  # Enables Isso on all posts. It can be enabled on individual posts by setting `isso = true` in the [extra] section of a post's front matter.
-automatic_loading = true  # If set to false, a "Load comments" button will be shown.
-endpoint_url = ""  # Accepts relative paths like "/comments/" or "/isso/", as well as full urls like "https://example.com/comments/". Include the trailing slash.
-page_id_is_slug = true  # If true, it will use the post's filename (slug) as id; this is the only way to share comments between languages. If false, it will use the entire url as id.
-lang = ""  # Leave blank to match the page's language.
-max_comments_top = "inf"  # Number of top level comments to show by default. If some comments are not shown, an “X Hidden” link is shown.
-max_comments_nested = "5"  # Number of nested comments to show by default. If some comments are not shown, an “X Hidden” link is shown.
-avatar = true
-voting = true
-page_author_hashes = ""  # hash (or list of hashes) of the author.
-lazy_loading = true  # Loads when the comments are in the viewport (using the Intersection Observer API).
+# enabled_for_all_posts = false  # Enables Isso on all posts. It can be enabled on individual posts by setting `isso = true` in the [extra] section of a post's front matter.
+# automatic_loading = true  # If set to false, a "Load comments" button will be shown.
+# endpoint_url = ""  # Accepts relative paths like "/comments/" or "/isso/", as well as full urls like "https://example.com/comments/". Include the trailing slash.
+# page_id_is_slug = true  # If true, it will use the post's filename (slug) as id; this is the only way to share comments between languages. If false, it will use the entire url as id.
+# lang = ""  # Leave blank to match the page's language.
+# max_comments_top = "inf"  # Number of top level comments to show by default. If some comments are not shown, an “X Hidden” link is shown.
+# max_comments_nested = "5"  # Number of nested comments to show by default. If some comments are not shown, an “X Hidden” link is shown.
+# avatar = true
+# voting = true
+# page_author_hashes = ""  # hash (or list of hashes) of the author.
+# lazy_loading = true  # Loads when the comments are in the viewport (using the Intersection Observer API).


### PR DESCRIPTION
This PR sets saner defaults for when settings are missing in a site using tabi but missing certain `config.toml` values.

For example, a missing extra.email in `config.toml` would render the `theme.toml` value of `mail@example.com`. Certain values like these have been commented out.

Also updates the git pre-commit hook to no longer sync the `[extra]` content of `config` and `theme.toml`, but rather compare the number of lines in each section and abort the commit if they don't match.

Fixes issue #125.