### PR TITLE
✨ feat(settings): add hierarchy-based setting overrides

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -142,20 +142,6 @@ language_name.ca = "Català"
 language_name.en = "English"
 language_name.es = "Español"
 
-# Remote repository for your Zola site.
-# Used for `show_remote_changes` and `show_remote_source` (see below).
-# Supports GitHub, GitLab, Gitea, and Codeberg.
-remote_repository_url = "https://github.com/welpo/tabi"
-# Set this to "auto" to try and auto-detect the platform based on the repository URL.
-# Accepted values are "github", "gitlab", "gitea", and "codeberg".
-remote_repository_git_platform = "auto"  # Defaults to "auto".
-# Branch in the repo hosting the Zola site.
-remote_repository_branch = "main"  # Defaults to "main".
-# Show a link to the commit history of updated posts, right next to the last updated date.
-show_remote_changes = true  # Defaults to true.
-# Show a link to the repository of the site, right next to the "Powered by Zola & tabi" text.
-show_remote_source = true  # Defaults to true.
-
 # Enable JavaScript theme toggler to allow users to switch between dark/light mode.
 # Also enables automatic switching based on user's OS-level theme settings.
 # If disabled, your site will only use the theme specified in the `default_theme` variable.
@@ -182,18 +168,41 @@ skin = ""
 # You can load a stylesheet for a single post by adding it to the [extra] section of the post's front matter, following this same format.
 stylesheets = []
 
+# Remote repository for your Zola site.
+# Used for `show_remote_changes` and `show_remote_source` (see below).
+# Supports GitHub, GitLab, Gitea, and Codeberg.
+remote_repository_url = "https://github.com/welpo/tabi"
+# Set this to "auto" to try and auto-detect the platform based on the repository URL.
+# Accepted values are "github", "gitlab", "gitea", and "codeberg".
+remote_repository_git_platform = "auto"  # Defaults to "auto".
+# Branch in the repo hosting the Zola site.
+remote_repository_branch = "main"  # Defaults to "main".
+# Show a link to the commit history of updated posts, right next to the last updated date.
+# Can be set at page or section levels, following the hierarchy: page > section > config. See: https://github.com/welpo/tabi/pull/128
+show_remote_changes = true  # Defaults to true.
+# Show a link to the repository of the site, right next to the "Powered by Zola & tabi" text.
+show_remote_source = true  # Defaults to true.
+
 # Add a "copy" button to codeblocks (loads ~700 bytes of JavaScript).
+# Can be set at page or section levels, following the hierarchy: page > section > config. See: https://github.com/welpo/tabi/pull/128
 copy_button = true
 
 # Show the reading time of a page.
-# Can also be enabled or disabled on individual pages in the front matter's [extra].
+# Can be set at page or section levels, following the hierarchy: page > section > config. See: https://github.com/welpo/tabi/pull/128
 show_reading_time = true
 
 # Adds backlinks to footnotes (loads ~500 bytes of JavaScripts).
+# Can be set at page or section levels, following the hierarchy: page > section > config. See: https://github.com/welpo/tabi/pull/128
 footnote_backlinks = false
 
 # Enable KaTeX for all posts.
+# Can be set at page or section levels, following the hierarchy: page > section > config. See: https://github.com/welpo/tabi/pull/128
 katex = false
+
+# Quick navigation buttons.
+# Adds "go up" and "go to comments" buttons on the bottom right (hidden for mobile).
+# Can be set at page or section levels, following the hierarchy: page > section > config. See: https://github.com/welpo/tabi/pull/128
+quick_navigation_buttons = false
 
 # Date format used when listing posts (main page, /blog section, tag posts list…)
 # Default is "6th July 2049" in English and "%d %B %Y" in other languages.
@@ -272,11 +281,6 @@ allowed_domains = [
 # This avoids a flashing text issue in Firefox.
 # Please see https://welpo.github.io/tabi/blog/custom-font-subset/ to learn how to create this file.
 custom_subset = true
-
-# Quick navigation buttons.
-# Adds "go up" and "go to comments" buttons on the bottom right (hidden for mobile).
-# Can also be enabled on individual posts in the front matter's [extra].
-quick_navigation_buttons = false
 
 # giscus support for comments. https://giscus.app
 # Setup instructions: https://welpo.github.io/tabi/blog/comments/#setup

--- a/content/blog/javascript.ca.md
+++ b/content/blog/javascript.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Sense JavaScript obligatori"
 date = 2023-01-06
-updated = 2023-08-18
+updated = 2023-09-01
 description = "JavaScript només s'utilitza quan HTML i CSS no són suficients."
 
 [taxonomies]
@@ -15,25 +15,30 @@ Aquest tema no requereix JavaScript obligatori. Opcionalment, pot carregar una q
 
 ## Opcions habilitades globalment
 
-- L'**interruptor de mode clar/fosc** pot habilitar-se configurant `theme_switcher = true` a la secció `[extra]` del teu `config.toml` (~900 bytes de JavaScript).
+- L'**interruptor de mode clar/fosc** es pot habilitar configurant `theme_switcher = true` a la secció `[extra]` del teu `config.toml` (~900 bytes de JavaScript).
+  
+- **Decodificació de correu electrònic** (~400 bytes). Per protegir contra robots de correu brossa, pots configurar `encode_plaintext_email = true`. Si el teu lloc web està en un repositori públic, considera utilitzar el teu `email` com una cadena codificada en base64[^1].
 
-- **Decodificació del correu** (~400 bytes). Per protegir el teu lloc correu dels [robots de correu brossa](https://ca.wikipedia.org/wiki/Robot_de_correu_brossa), pots configurar `encode_plaintext_email = true`. Si el teu lloc web està en un repositori públic, per a una protecció millorada, considera configurar el teu `email` com una cadena codificada en base64[^1] directament (per exemple: `email = "bWFpbEBleGFtcGxlLmNvbQ=="`).
+## Opcions que es poden sobreescriure de forma jeràrquica
 
-## Configuracions que es poden habilitar tant globalment com en publicacions individuals
+Les següents opcions es poden especificar per a publicacions, seccions i globalment, seguint la jerarquia de `pàgina > secció > config.toml`:
 
-Les següents configuracions es poden habilitar globalment per a totes les pàgines o específicament per a publicacions individuals:
-
-- [**KaTeX**](@/blog/markdown.ca.md#katex). Habilitat configurant `katex = true` (274 KB).
+- [**Suport de KaTeX**](@/blog/markdown.ca.md#katex). Habilitat configurant `katex = true` (274 KB).
 - [**Còpia de blocs de codi amb un sol clic**](@/blog/markdown.ca.md#bloc-de-codi). Habilitada configurant `copy_button = true`. (~700 bytes)
-- [**Enllaços de retorn de notes al peu de pàgina**](@/blog/markdown.ca.md#1). Habilitats configurant `footnote_backlinks = true` (~500 bytes).
+- [**Enllaços de retorn per a notes a peu de pàgina**](@/blog/markdown.ca.md#1). Habilitats configurant `footnote_backlinks = true` (~500 bytes).
 
-Per habilitar aquestes configuracions globalment, afegeix-les a la secció `[extra]` del teu `config.toml`. Per habilitar-les en publicacions individuals, estableix les variables corresponents a l'apartat `[extra]` del front matter de la publicació.
+Per especificar aquestes opcions:
 
-- [**Comentaris**](@/blog/comments.ca.md). giscus (2 KB), utterances (1 KB), Hyvor Talk (~800 bytes) o Isso (1KB) es poden habilitar globalment configurant `enabled_for_all_posts = true` a la secció apropiada del teu fitxer `config.toml` (`[extra.giscus]`, `[extra.utterances]`, `[extra.hyvortalk]` o `[extra.isso]`). Per habilitar comentaris en publicacions individuals, configura el nom del sistema `= true` (per exemple, `hyvort
-- [**Comentaris**](@/blog/comments.ca.md). giscus (2 KB), utterances (1 KB), Hyvor Talk (~800 bytes) o Isso (1KB) es poden habilitar globalment configurant `enabled_for_all_posts = true` a la secció apropiada del teu fitxer `config.toml` (`[extra.giscus]`, `[extra.utterances]`, `[extra.hyvortalk]` o `[extra.isso]`). Per habilitar comentaris en publicacions individuals, configura el nom del sistema `= true` (per exemple, `hyvortalk = true`) al front matter del post.
+- **Globalment**: Afegeix-les sota la secció `[extra]` al teu `config.toml`.
+- **Per a una secció**: Afegeix-les sota la secció `[extra]` al front matter de l'`_index.md` de la secció.
+- **Per a una publicació individual**: Configura les variables corresponents a la secció `[extra]` del front matter de la publicació.
+
+## Opcions que es poden habilitar globalment o per a publicacions individuals
+
+- [**Comentaris**](@/blog/comments.ca.md). giscus (2 KB), utterances (1 KB), Hyvor Talk (~800 bytes) o Isso (1KB) es poden habilitar globalment configurant `enabled_for_all_posts = true` a la secció apropiada del teu `config.toml` (`[extra.giscus]`, `[extra.utterances]`, `[extra.hyvortalk]` o `[extra.isso]`). Per habilitar comentaris en publicacions individuals, configura el nom del sistema `= true` (per exemple, `hyvortalk = true`) al front matter del post.
 
 A part d'això, és un tema ràpid amb HTML i CSS que funciona sense JavaScript. Just com hauria de ser (la majoria de) la web :-)
 
-<hr>
+---
 
 [^1]: Per codificar el teu correu en base64 pots utilitzar [eines en línia](https://www.base64encode.org/) o, al terminal, executa: `printf 'mail@example.com' | base64`.

--- a/content/blog/javascript.es.md
+++ b/content/blog/javascript.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Sin JavaScript obligatorio"
 date = 2023-01-06
-updated = 2023-08-18
+updated = 2023-09-01
 description = "JavaScript solo se utiliza cuando HTML y CSS no son suficientes."
 
 [taxonomies]
@@ -11,28 +11,34 @@ tags = ["funcionalidad", "tutorial"]
 footnote_backlinks = true
 +++
 
-Este tema no tiene JavaScript obligatorio. Opcionalmente, puede cargar una cantidad mínima para agregar algunas características que son imposibles de lograr con HTML y CSS.
+Este tema no requiere JavaScript de manera obligatoria. Opcionalmente, puede cargar una cantidad mínima de JavaScript para añadir algunas características que son imposibles de lograr con solo HTML y CSS.
 
 ## Opciones habilitadas globalmente
 
 - El **interruptor de modo claro/oscuro** puede habilitarse configurando `theme_switcher = true` en la sección `[extra]` de tu `config.toml` (~900 bytes de JavaScript).
+  
+- **Descodificación de correo electrónico** (~400 bytes). Para proteger contra bots que recopilan correos electrónicos desde tu sitio web, puedes configurar `encode_plaintext_email = true`. Si tu sitio está en un repositorio público, para mayor protección, considera configurar tu `email` como una cadena codificada en base64[^1].
 
-- **Decodificación de correo electrónico** (~400 bytes). Para protegerte contra los bots que escanean tu correo electrónico desde tu sitio web, puedes configurar `encode_plaintext_email = true`. Si tu sitio está en un repositorio público, para una protección extra, considera configurar tu `email` como una cadena codificada en base64[^1] directamente.
+## Opciones que se pueden sobreescribir de forma jerárquica
 
-## Configuraciones que pueden habilitarse tanto globalmente como en publicaciones individuales
+Las siguientes opciones pueden especificarse para publicaciones, secciones y a nivel global, siguiendo la jerarquía de `página > sección > config.toml`:
 
-Las siguientes configuraciones pueden habilitarse globalmente para todas las páginas o específicamente para publicaciones individuales:
+- [**Soporte de KaTeX**](@/blog/markdown.es.md#katex). Habilitado al configurar `katex = true` (274 KB).
+- [**Copia de bloques de código con un solo clic**](@/blog/markdown.es.md#bloque-de-codigo). Habilitado al configurar `copy_button = true` (~700 bytes).
+- [**Enlaces de retorno de notas al pie**](@/blog/markdown.es.md#1). Habilitado al configurar `footnote_backlinks = true` (~500 bytes).
 
-- [**KaTeX**](@/blog/markdown.es.md#katex). Habilitado configurando `katex = true` (274 KB).
-- [**Copia de bloques de código con un solo clic**](@/blog/markdown.es.md#bloque-de-codigo). Habilitada configurando `copy_button = true`. (~700 bytes)
-- [**Enlaces de retorno de notas al pie**](@/blog/markdown.es.md#1). Habilitados configurando `footnote_backlinks = true` (~500 bytes).
+Para especificar estas opciones:
 
-Para habilitar estas configuraciones globalmente, añádelas en la sección `[extra]` de tu `config.toml`. Para habilitarlas en publicaciones individuales, establece las variables correspondientes en el apartado `[extra]` del front matter de la publicación.
+- **Globalmente**: Añádelas en la sección `[extra]` de tu `config.toml`.
+- **Para una sección**: Añádelas en la sección `[extra]` del front matter del `_index.md` de la sección.
+- **Para una publicación individual**: Configura las variables correspondientes en la sección `[extra]` del front matter de la publicación.
 
-- [**Comentarios**](@/blog/comments.es.md). giscus (2 KB), utterances (1 KB), Hyvor Talk (~800 bytes) o Isso (1KB) se pueden habilitar globalmente configurando `enabled_for_all_posts = true` en el apartado apropiado de tu archivo `config.toml` (`[extra.giscus]`, `[extra.utterances]`, `[extra.hyvortalk]` o `[extra.isso]`). Para habilitar comentarios en publicaciones individuales, configura el nombre del sistema `= true` (por ejemplo, `hyvortalk = true`) en el front matter del post.
+## Opciones que pueden habilitarse globalmente o para publicaciones individuales
 
-Aparte de eso, es un tema rápido con HTML y CSS que funciona con JavaScript deshabilitado. Justo como debería ser (en su mayoría) la web :-)
+- [**Comentarios**](@/blog/comments.es.md). giscus (2 KB), utterances (1 KB), Hyvor Talk (~800 bytes) o Isso (1KB) pueden habilitarse globalmente configurando `enabled_for_all_posts = true` en la sección apropiada de tu `config.toml` (`[extra.giscus]`, `[extra.utterances]`, `[extra.hyvortalk]` o `[extra.isso]`). Para habilitar comentarios en publicaciones individuales, configura el nombre del sistema `= true` (por ejemplo, `hyvortalk = true`) en el front matter de la publicación.
 
-<hr>
+Aparte de eso, es un tema rápido con HTML y CSS que funciona con JavaScript deshabilitado. Justo como debería ser (la mayoría de) la web :-)
 
-[^1]: Para codificar tu correo en base64 puedes usar [herramientas en línea](https://www.base64encode.org/) o, en tu terminal, ejecuta: `printf '
+---
+
+[^1]: Para codificar tu correo electrónico en base64 puedes usar [herramientas en línea](https://www.base64encode.org/) o, en tu terminal, ejecutar: `printf 'mail@example.com' | base64`.

--- a/content/blog/javascript.md
+++ b/content/blog/javascript.md
@@ -1,7 +1,7 @@
 +++
 title = "No mandatory JavaScript"
 date = 2023-01-06
-updated = 2023-08-18
+updated = 2023-09-01
 description = "JavaScript is only used when HTML and CSS aren't enough."
 
 [taxonomies]
@@ -19,20 +19,26 @@ This theme has no mandatory JavaScript. Optionally, it can load a minimal amount
 
 - **E-mail decoding** (~400 bytes). To protect against spambots scraping your e-mail from your website, you can set `encode_plaintext_email = true`. If your site is on a public repository, for extra protection, consider setting your `email` as a base64-encoded string[^1] directly.
 
-## Settings that can be enabled globally and for individual posts
+## Settings with hierarchical override capability
 
-The following settings can be enabled globally for all pages or specifically for individual posts:
+The following settings can be specified for posts, sections and globally, following the hierarchy of `page > section > config.toml`:
 
 - [**KaTeX support**](@/blog/markdown.md#katex). Enabled by setting `katex = true` (274 KB).
 - [**One-click copy of code blocks**](@/blog/markdown.md#code-block). Enabled by setting `copy_button = true`. (~700 bytes)
 - [**Footnote backlinks**](@/blog/markdown.md#1). Enabled by setting `footnote_backlinks = true` (~500 bytes).
 
-To enable these settings globally, add them in the `[extra]` section of your `config.toml` file. To enable for individual posts, set the corresponding variables in the `[extra]` section of the post's front matter.
+To specify these settings:
+
+- **Globally**: Add them under the `[extra]` section in your `config.toml` file.
+- **For a section**: Add them under the `[extra]` section in the front matter of the section's `_index.md`.
+- **For an individual post**: Set the corresponding variables in the `[extra]` section of the post's front matter.
+
+## Settings that can be enabled globally or for individual posts
 
 - [**Comments**](@/blog/comments.md). giscus (2 KB), utterances (1 KB), Hyvor Talk (~800 bytes) or Isso (1KB) can be globally enabled by setting `enabled_for_all_posts = true` in the right section of your  `config.toml` (i.e. `[extra.giscus]`, `[extra.utterances]`, `[extra.hyvortalk]` or `[extra.isso]`). To enable comments on individual posts, set the name of the system `= true` (e.g. `hyvortalk = true`) in the post's front matter.
 
 Other than that, it's a fast theme with HTML and CSS which works with JavaScript disabled. Just the way (most of) the web should be :-)
 
-<hr>
+---
 
 [^1]: To encode your email in base64 you can use [online tools](https://www.base64encode.org/) or, on your terminal, run: `printf 'mail@example.com' | base64`.

--- a/content/blog/markdown.ca.md
+++ b/content/blog/markdown.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Exemples de Markdown"
 date = 2023-01-31
-updated = 2023-08-06
+updated = 2023-09-01
 description = "Aquesta publicació mostra alguns exemples de format en Markdown, incloent-hi una taula, blocs de codi i etiquetes, citacions, taules i notes a peu de pàgina."
 
 [taxonomies]
@@ -24,7 +24,7 @@ Per mostrar l'expressió **en una línia pròpia i centrada**, embolcalla-la amb
 
 Per exemple, `\\[ r = \frac{\sum_{i=1}^{n}(x_i - \bar{x})(y_i - \bar{y})}{\sqrt{\sum_{i=1}^{n}(x_i - \bar{x})^2}\sqrt{\sum_{i=1}^{n}(y_i - \bar{y})^2}} \\]` es renderitzarà com: \\[ r = \frac{\sum_{i=1}^{n}(x_i - \bar{x})(y_i - \bar{y})}{\sqrt{\sum_{i=1}^{n}(x_i - \bar{x})^2}\sqrt{\sum_{i=1}^{n}(y_i - \bar{y})^2}} \\]
 
-Per activar $\KaTeX$ en una publicació, inclou `katex = true` dins de la secció `[extra]` dels metadades de la publicació. Per exemple:
+Per activar $\KaTeX$ en una publicació o secció sencera, inclou `katex = true` dins de la secció `[extra]` de les metadades. Per exemple:
 
 ```toml,hl_lines=5-6
 +++

--- a/content/blog/markdown.es.md
+++ b/content/blog/markdown.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Ejemplos de Markdown"
 date = 2023-01-31
-updated = 2023-08-06
+updated = 2023-09-01
 description = "Esta publicación muestra algunos ejemplos de formato Markdown, incluyendo una tabla, bloques de código y etiquetas, citas, tablas y notas al pie de página."
 
 [taxonomies]
@@ -24,7 +24,7 @@ Para mostrar la expresión **en su propia línea y centrada**, envuélvela entre
 
 Por ejemplo, `\\[ r = \frac{\sum_{i=1}^{n}(x_i - \bar{x})(y_i - \bar{y})}{\sqrt{\sum_{i=1}^{n}(x_i - \bar{x})^2}\sqrt{\sum_{i=1}^{n}(y_i - \bar{y})^2}} \\]` se mostraría como: \\[ r = \frac{\sum_{i=1}^{n}(x_i - \bar{x})(y_i - \bar{y})}{\sqrt{\sum_{i=1}^{n}(x_i - \bar{x})^2}\sqrt{\sum_{i=1}^{n}(y_i - \bar{y})^2}} \\]
 
-Para activar $\KaTeX$ en una publicación, incluye `katex = true` dentro de la sección `[extra]` del encabezado de la publicación. Por ejemplo:
+Para activar $\KaTeX$ en una publicación o sección entera, incluye `katex = true` dentro de la sección `[extra]` del encabezado. Por ejemplo:
 
 ```toml,hl_lines=5-6
 +++

--- a/content/blog/markdown.md
+++ b/content/blog/markdown.md
@@ -1,7 +1,7 @@
 +++
 title = "Markdown examples"
 date = 2023-01-31
-updated = 2023-08-02
+updated = 2023-09-01
 description = "This post showcases some examples of Markdown formatting, including a table, code blocks and tags, quotes, tables, and footnotes."
 
 [taxonomies]
@@ -24,7 +24,7 @@ To display the expression **on its own line and centered**, wrap it around `$$` 
 
 For example, `\\[ r = \frac{\sum_{i=1}^{n}(x_i - \bar{x})(y_i - \bar{y})}{\sqrt{\sum_{i=1}^{n}(x_i - \bar{x})^2}\sqrt{\sum_{i=1}^{n}(y_i - \bar{y})^2}} \\]` renders: \\[ r = \frac{\sum_{i=1}^{n}(x_i - \bar{x})(y_i - \bar{y})}{\sqrt{\sum_{i=1}^{n}(x_i - \bar{x})^2}\sqrt{\sum_{i=1}^{n}(y_i - \bar{y})^2}} \\]
 
-To activate $\KaTeX$ for a post, include `katex = true` within the `[extra]` section of the post's front matter. For exemple:
+To activate $\KaTeX$ for a post or an entire section, include `katex = true` within the `[extra]` section of the front matter. For exemple:
 
 ```toml,hl_lines=5-6
 +++

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,7 @@
 {% import "macros/paginate.html" as macros_paginate %}
 {% import "macros/rel_attributes.html" as macros_rel_attributes %}
 {% import "macros/set_title.html" as macros_set_title %}
+{% import "macros/settings.html" as macros_settings %}
 {% import "macros/table_of_contents.html" as macros_toc %}
 
 <!DOCTYPE html>
@@ -27,23 +28,6 @@
             Nothing here?!
         {% endblock main_content %}
     </div>
-    {% include "partials/footer.html" %}
-
-    {# Add KaTeX functionality (loads CSS and JS) #}
-    {%- if config.extra.katex and config.extra.katex == true or page.extra.katex and page.extra.katex == true -%}
-        <link rel="stylesheet" href="{{ get_url(path='katex.min.css', trailing_slash=false) | safe }}">
-        <script defer src="{{ get_url(path='js/katex.min.js', trailing_slash=false) | safe }}"></script>
-    {%- endif -%}
-
-    {# Add copy button to codeblocks #}
-    {%- if config.extra.copy_button and config.extra.copy_button == true or page.extra.copy_button and page.extra.copy_button == true -%}
-        <script defer src="{{ get_url(path='js/copyCodeToClipboard.min.js', trailing_slash=false) | safe }}"/></script>
-    {%- endif -%}
-
-    {# Add backlinks to footnotes #}
-    {%- if config.extra.footnote_backlinks and config.extra.footnote_backlinks == true or page.extra.footnote_backlinks and page.extra.footnote_backlinks == true -%}
-        <script defer src="{{ get_url(path='js/footnoteBacklinks.min.js', trailing_slash=false | safe )}}"/></script>
-    {%- endif -%}
 </body>
 
 </html>

--- a/templates/macros/content.html
+++ b/templates/macros/content.html
@@ -10,6 +10,42 @@
     {%- set blank_target = "" -%}
 {%- endif -%}
 
+{# Debugging #}
+{# {% set last_ancestor = page.ancestors | slice(start=-1) %}
+{% set current_section = get_section(path=last_ancestor.0) %}
+
+{% set settings_to_test = [
+    "footnote_backlinks",
+    "katex",
+    "quick_navigation_buttons",
+    "show_reading_time",
+    "show_remote_changes"
+] %}
+
+<table>
+    <thead>
+        <tr>
+            <th>setting</th>
+            <th>page</th>
+            <th>section</th>
+            <th>config</th>
+            <th>macro output</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for setting in settings_to_test %}
+            <tr>
+                <td><code>{{ setting }}</code></td>
+                <td>{{ page.extra[setting] | default(value="⬛") }}</td>
+                <td>{{ current_section.extra[setting] | default(value="⬛") }}</td>
+                <td>{{ config.extra[setting] | default(value="⬛") }}</td>
+                <td>{{ macros_settings::evaluate_setting_priority(setting=setting, page=page) }}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table> #}
+{# End debugging #}
+
 <main>
     <article>
         <div class="article-title">
@@ -26,7 +62,7 @@
             {% endif %}
 
             {# page settings override config settings #}
-            {% if page.extra.show_reading_time | default(value="") == true or page.extra.show_reading_time | default(value="") != false and config.extra.show_reading_time | default(value=true) %}
+            {% if macros_settings::evaluate_setting_priority(setting="show_reading_time", page=page, default_global_value=true) == "true" %}
                 {{ separator }} <li title="{{ page.word_count }} {%- if lang != config.default_language %} {{ trans(key="words" | safe, lang=lang) }} {% else %} words {% endif %}">{{ page.reading_time }}{%- if lang != config.default_language %} {{ trans(key="min_read" | safe, lang=lang) }} {% else %} min read {% endif %}</li>
             {% endif %}
 
@@ -44,8 +80,7 @@
             {% if page.updated %}
                 </ul><ul class="meta last-updated"><li>{%- if lang != config.default_language %} {{ trans(key="last_updated_on" | safe, lang=lang) }} {% else %} Last updated on {% endif %} {{ macros_format_date::format_date(date=page.updated, short=true) }}</li>
                 {# Show link to remote changes if enabled #}
-                {% set show_remote_changes = config.extra.show_remote_changes | default(value=true) %}
-                {% if config.extra.remote_repository_url and show_remote_changes %}
+                {% if config.extra.remote_repository_url and macros_settings::evaluate_setting_priority(setting="show_remote_changes", page=page, default_global_value=true) == "true" %}
                     <li>&nbsp;{{ separator }}&nbsp;<a href="{{ macros_create_history_url::create_history_url(relative_path=page.relative_path) }}" {{ blank_target }} rel="{{ rel_attributes }}">{%- if lang != config.default_language -%}{{ trans(key="see_changes" | safe, lang=lang) }}{% else %}See changes{%- endif -%}<small> ↗</small></a></li>
                 {% endif %}
             {% endif %}
@@ -110,7 +145,8 @@
     </article>
 </main>
 
-{% if config.extra.quick_navigation_buttons or page.extra.quick_navigation_buttons %}
+{# Quick navigation buttons #}
+{% if macros_settings::evaluate_setting_priority(setting="quick_navigation_buttons", page=page, default_global_value=false) == "true" %}
     <div id="button-container">
         {# Button to go show a floating Table of Contents #}
         {% if page.toc %}
@@ -139,5 +175,21 @@
         </a>
     </div>
 {% endif %}
+
+{# Add KaTeX functionality #}
+{%- if macros_settings::evaluate_setting_priority(setting="katex", page=page, default_global_value=false) == "true" -%}
+    <link rel="stylesheet" href="{{ get_url(path='katex.min.css', trailing_slash=false) | safe }}">
+    <script defer src="{{ get_url(path='js/katex.min.js', trailing_slash=false) | safe }}"></script>
+{%- endif -%}
+
+{# Add copy button to code blocks #}
+{%- if macros_settings::evaluate_setting_priority(setting="copy_button", page=page, default_global_value=true) == "true" -%}
+    <script defer src="{{ get_url(path='js/copyCodeToClipboard.min.js', trailing_slash=false) | safe }}"/></script>
+{%- endif -%}
+
+{# Add backlinks to footnotes #}
+{%- if macros_settings::evaluate_setting_priority(setting="footnote_backlinks", page=page, default_global_value=false) == "true" -%}
+    <script defer src="{{ get_url(path='js/footnoteBacklinks.min.js', trailing_slash=false | safe )}}"/></script>
+{%- endif -%}
 
 {% endmacro content %}

--- a/templates/macros/settings.html
+++ b/templates/macros/settings.html
@@ -1,0 +1,40 @@
+{# 
+Evaluates the priority of a particular setting across different scopes.
+
+The priority is as follows: page > section > config.
+
+Parameters:
+    - setting: The name of the setting to evaluate.
+    - page: The page object containing settings.
+    - default_global_value: The setting's default value.
+#}
+
+{% macro evaluate_setting_priority(setting, page) %}
+
+{#- Retrieve last ancestor to determine current section, if applicable -#}
+{%- if page -%}
+    {%- set last_ancestor = page.ancestors | slice(start=-1) %}
+    {%- set current_section = get_section(path=last_ancestor.0) %}
+{%- endif -%}
+
+{%- set priority_order = [
+    page.extra[setting] | default(value=""),
+    current_section.extra[setting] | default(value=""),
+    config.extra[setting] | default(value=default_global_value)
+] -%}
+
+{%- set output = "false" -%}
+
+{%- for value in priority_order -%}
+    {%- if value == true -%}
+        {%- set_global output = "true" -%}
+        {%- break -%}
+    {%- elif value == false -%}
+        {%- set_global output = "false" -%}
+        {%- break -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{{- output -}}
+
+{% endmacro %}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -85,9 +85,8 @@
                 {%- endif -%} 
                 &nbsp;<a rel="{{ rel_attributes }}" {{ blank_target }} href="https://github.com/welpo/tabi">tabi</a>
 
-                {# Shows link to remote repository if repository is set and `show_remote_source` is not false #}
-                {% set show_source = config.extra.show_remote_source | default(value=true) %}
-                {%- if config.extra.remote_repository_url and show_source -%}
+                {# Shows link to remote repository #}
+                {%- if config.extra.remote_repository_url and config.extra.show_remote_source | default(value=true) -%}
                 {{ separator }}
                     <a rel="{{ rel_attributes }}" {{ blank_target }} href="{{ config.extra.remote_repository_url }}">
                         {%- if lang != config.default_language -%}

--- a/theme.toml
+++ b/theme.toml
@@ -27,20 +27,6 @@ homepage = "https://osc.garden"
 # language_name.en = "English"
 # language_name.es = "Español"
 
-# Remote repository for your Zola site.
-# Used for `show_remote_changes` and `show_remote_source` (see below).
-# Supports GitHub, GitLab, Gitea, and Codeberg.
-# remote_repository_url = "https://github.com/welpo/tabi"
-# Set this to "auto" to try and auto-detect the platform based on the repository URL.
-# Accepted values are "github", "gitlab", "gitea", and "codeberg".
-remote_repository_git_platform = "auto"  # Defaults to "auto".
-# Branch in the repo hosting the Zola site.
-remote_repository_branch = "main"  # Defaults to "main".
-# Show a link to the commit history of updated posts, right next to the last updated date.
-show_remote_changes = true  # Defaults to true.
-# Show a link to the repository of the site, right next to the "Powered by Zola & tabi" text.
-show_remote_source = true  # Defaults to true.
-
 # Enable JavaScript theme toggler to allow users to switch between dark/light mode.
 # Also enables automatic switching based on user's OS-level theme settings.
 # If disabled, your site will only use the theme specified in the `default_theme` variable.
@@ -67,18 +53,41 @@ skin = ""
 # You can load a stylesheet for a single post by adding it to the [extra] section of the post's front matter, following this same format.
 stylesheets = []
 
+# Remote repository for your Zola site.
+# Used for `show_remote_changes` and `show_remote_source` (see below).
+# Supports GitHub, GitLab, Gitea, and Codeberg.
+# remote_repository_url = "https://github.com/welpo/tabi"
+# Set this to "auto" to try and auto-detect the platform based on the repository URL.
+# Accepted values are "github", "gitlab", "gitea", and "codeberg".
+remote_repository_git_platform = "auto"  # Defaults to "auto".
+# Branch in the repo hosting the Zola site.
+remote_repository_branch = "main"  # Defaults to "main".
+# Show a link to the commit history of updated posts, right next to the last updated date.
+# Can be set at page or section levels, following the hierarchy: page > section > config. See: https://github.com/welpo/tabi/pull/128
+show_remote_changes = true  # Defaults to true.
+# Show a link to the repository of the site, right next to the "Powered by Zola & tabi" text.
+show_remote_source = true  # Defaults to true.
+
 # Add a "copy" button to codeblocks (loads ~700 bytes of JavaScript).
+# Can be set at page or section levels, following the hierarchy: page > section > config. See: https://github.com/welpo/tabi/pull/128
 copy_button = true
 
 # Show the reading time of a page.
-# Can also be enabled or disabled on individual pages in the front matter's [extra].
+# Can be set at page or section levels, following the hierarchy: page > section > config. See: https://github.com/welpo/tabi/pull/128
 show_reading_time = true
 
 # Adds backlinks to footnotes (loads ~500 bytes of JavaScripts).
+# Can be set at page or section levels, following the hierarchy: page > section > config. See: https://github.com/welpo/tabi/pull/128
 footnote_backlinks = false
 
 # Enable KaTeX for all posts.
+# Can be set at page or section levels, following the hierarchy: page > section > config. See: https://github.com/welpo/tabi/pull/128
 katex = false
+
+# Quick navigation buttons.
+# Adds "go up" and "go to comments" buttons on the bottom right (hidden for mobile).
+# Can be set at page or section levels, following the hierarchy: page > section > config. See: https://github.com/welpo/tabi/pull/128
+quick_navigation_buttons = false
 
 # Date format used when listing posts (main page, /blog section, tag posts list…)
 # Default is "6th July 2049" in English and "%d %B %Y" in other languages.
@@ -157,11 +166,6 @@ allowed_domains = [
 # This avoids a flashing text issue in Firefox.
 # Please see https://welpo.github.io/tabi/blog/custom-font-subset/ to learn how to create this file.
 # custom_subset = true
-
-# Quick navigation buttons.
-# Adds "go up" and "go to comments" buttons on the bottom right (hidden for mobile).
-# Can also be enabled on individual posts in the front matter's [extra].
-# quick_navigation_buttons = true
 
 # giscus support for comments. https://giscus.app
 # Setup instructions: https://welpo.github.io/tabi/blog/comments/#setup


### PR DESCRIPTION
<details>
  <summary><b>TL;DR</b></summary>
  Adds hierarchical setting overrides with priority: page > section > <code>config.toml</code>.
</details>

## Description

This PR introduces a new feature that allows for hierarchical overriding of most settings (see list below). The priority of the settings is evaluated as page > section > `config.toml`.

Related issue: #124 

### Changes
- Adds a new macro (`evaluate_setting_priority`, in `settings.html`) to handle hierarchical setting logic.
- Updates `config.toml` and `theme.toml` to document the new hierarchy logic for each pertinent setting.
- Moved the loading logic for `katex`, `copy_button`, and `footnote_backlinks` from `base.html` to `content.html`.

## Priority Table

Here is how the priority is evaluated:

| page | section | `config.toml` | outcome |
|:----:|:-------:|:-------------:|:-------:|
|  ✅  |   Any   |      Any      |    ✅   |
|  ❌  |   Any   |      Any      |    ❌   |
|  ⬛  |   ✅    |      Any      |    ✅   |
|  ⬛  |   ❌    |      Any      |    ❌   |
|  ⬛  |   ⬛    |      ✅       |    ✅   |
|  ⬛  |   ⬛    |      ❌       |    ❌   |
|  ⬛  |   ⬛    |      ⬛       | default |

Legend:
- ✅: `true`
- ❌: `false`
- ⬛: unset

## Default Settings

The `default` value of the settings which follow this hierarchy is as follows:

| setting                | default |
|------------------------|---------|
| show_reading_time      | `true`  |
| footnote_backlinks     | `false` |
| katex                  | `false` |
| quick_navigation_buttons | `false`|
| copy_button            | `true`  |
| show_remote_changes    | `true`  |

## Example

If you'd like to **only** show the reading time on posts within your blog section, you could set `config.toml` like:

```toml
[extra]
show_reading_time = false
```

And in your `_index.md` (in `content/blog`):
```toml
paginate_by = 5
path = "/blog"
title = "Blog"
sort_by = "date"
template = "section.html"
insert_anchor_links = "left"

[extra]
show_reading_time = true
```

### Note: the macro only checks the parent section, not all ancestors.

---

Additionally, I added some [debugging code](https://github.com/welpo/tabi/blob/4e1ad5232e711a255b1414b0394bf53fdb66231b/templates/macros/content.html#L13-L47) on top of `content.html` (commented out) to assist in troublehsooting. It creates a table on top of the articles like this:

![debugging](https://github.com/welpo/tabi/assets/6399341/5b2453ce-bc09-4834-8e34-115f16d8703a)

---

## Tasks

- [x] Review the code
- [x] Ensure the pages look the same as the main branch
- [x] Update `markdown.md` and `javascript.md` files to mention the hierarchy where relevant.