### PR TITLE
♻️ refactor(translation): streamline translation logic with macro

### DIFF
--- a/static/feed_style.xsl
+++ b/static/feed_style.xsl
@@ -19,7 +19,7 @@
         <div class="content">
           <main>
             <div class="info-box">
-              <strong><xsl:value-of select="/atom:feed/str:translations/str:this_is_a_web_feed" /></strong>, <xsl:value-of select="/atom:feed/str:translations/str:also_known_as_an_Atom_feed" />. <strong><xsl:value-of select="/atom:feed/str:translations/str:subscribe" /></strong> <xsl:text> </xsl:text><xsl:value-of select="/atom:feed/str:translations/str:by_copying_the_URL_from_the_address_bar_into_your_newsreader" />.<xsl:text> </xsl:text><xsl:value-of select="/atom:feed/str:translations/str:visit" /><xsl:text> </xsl:text><a href="https://aboutfeeds.com">About Feeds</a><xsl:text> </xsl:text><xsl:value-of select="/atom:feed/str:translations/str:to_learn_more_and_get_started" />.<xsl:text> </xsl:text><xsl:value-of select="/atom:feed/str:translations/str:it_s_free" />.
+              <strong><xsl:value-of select="/atom:feed/str:translations/str:this_is_a_web_feed"/></strong>, <xsl:value-of select="/atom:feed/str:translations/str:also_known_as_an_Atom_feed" />. <strong><xsl:value-of select="/atom:feed/str:translations/str:subscribe" /></strong> <xsl:text> </xsl:text><xsl:value-of select="/atom:feed/str:translations/str:by_copying_the_URL_from_the_address_bar_into_your_newsreader" />.<xsl:text> </xsl:text><xsl:value-of select="/atom:feed/str:translations/str:visit" /><xsl:text> </xsl:text><a href="https://aboutfeeds.com">About Feeds</a><xsl:text> </xsl:text><xsl:value-of select="/atom:feed/str:translations/str:to_learn_more_and_get_started" />.<xsl:text> </xsl:text><xsl:value-of select="/atom:feed/str:translations/str:it_s_free" />.
             </div>
             <section id="banner-home-subtitle">
             <div class="padding-top home-title">

--- a/templates/404.html
+++ b/templates/404.html
@@ -11,7 +11,7 @@
         {# Iterate through each language and display the localised 404 message along with a "Go Home" link #}
         {%- for language_name, language in config.languages -%}
             {%- if language_name != config.default_language -%}
-                <p>{{ trans(key="404_error", lang=language_name) }} <a href="{{ config.base_url }}/{{ language_name }}/">{{ trans(key="go_home", lang=language_name) }}</a>.</p>
+                <p>{{ macros_translate::translate(key="404_error", force_lang=language_name) }} <a href="{{ config.base_url }}/{{ language_name }}/">{{ macros_translate::translate(key="go_home", force_lang=language_name) }}</a>.</p>
             {%- endif -%}
         {%- endfor -%}
     </main>

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -5,11 +5,7 @@
 {{ macros_page_header::page_header(title=section.title) }}
 
 {# Set locale for date #}
-{%- if lang != config.default_language %}
-    {% set date_locale = trans(key="date_locale" | safe, lang=lang) %}
-{% else %}
-    {% set date_locale = "en_GB" %}
-{% endif %}
+{% set date_locale = macros_translate::translate(key="date_locale", default="en_GB") %}
 
 <div class="archive">
     <ul class="list-with-title">

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -1,34 +1,36 @@
+{% import "macros/translate.html" as macros_translate %}
+
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="{{ get_url(path='/feed_style.xsl', trailing_slash=false) | safe }}" type="text/xsl"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:base="http://purl.org/atompub/base/1.0/" xml:lang="{{ lang }}" xml:base="{{ config.base_url }}">
     {# This section stores the strings/translations for the stylised feed. If the translation is not found, the default English text will be used. #}
     <str:translations xmlns:str="https://github.com/welpo/tabi">
         <str:this_is_a_web_feed>
-            {%- if lang != config.default_language -%} {{ trans(key="this_is_a_web_feed" | safe, lang=lang) }} {%- else -%} This is a web feed {%- endif -%}
+            {{- macros_translate::translate(key="this_is_a_web_feed", default="This is a web feed") -}}
         </str:this_is_a_web_feed>
         <str:also_known_as_an_Atom_feed>
-            {%- if lang != config.default_language -%} {{ trans(key="also_known_as_an_Atom_feed" | safe, lang=lang) }} {%- else -%} also known as an Atom feed {%- endif -%}
+            {{- macros_translate::translate(key="also_known_as_an_Atom_feed", default="also known as an Atom feed") -}}
         </str:also_known_as_an_Atom_feed>
         <str:subscribe>
-            {%- if lang != config.default_language -%} {{ trans(key="subscribe" | safe, lang=lang) }} {%- else -%} Subscribe {%- endif -%}
+            {{- macros_translate::translate(key="subscribe", default="Subscribe") -}}
         </str:subscribe>
         <str:by_copying_the_URL_from_the_address_bar_into_your_newsreader>
-            {%- if lang != config.default_language -%} {{ trans(key="by_copying_the_URL_from_the_address_bar_into_your_newsreader" | safe, lang=lang) }} {%- else -%} by copying the URL from the address bar into your newsreader {%- endif -%}
+            {{- macros_translate::translate(key="by_copying_the_URL_from_the_address_bar_into_your_newsreader", default="by copying the URL from the address bar into your newsreader") -}}
         </str:by_copying_the_URL_from_the_address_bar_into_your_newsreader>
         <str:visit>
-            {%- if lang != config.default_language -%} {{ trans(key="visit" | safe, lang=lang) }} {%- else -%} Visit {%- endif -%}
+            {{- macros_translate::translate(key="visit", default="Visit") -}}
         </str:visit>
         <str:to_learn_more_and_get_started>
-            {%- if lang != config.default_language -%} {{ trans(key="to_learn_more_and_get_started" | safe, lang=lang) }} {%- else -%} to learn more and get started {%- endif -%}
+            {{- macros_translate::translate(key="to_learn_more_and_get_started", default="to learn more and get started") -}}
         </str:to_learn_more_and_get_started>
         <str:it_s_free>
-            {%- if lang != config.default_language -%} {{ trans(key="it_s_free" | safe, lang=lang) }} {%- else -%} It's free {%- endif -%}
+            {{- macros_translate::translate(key="it_s_free", default="It's free") -}}
         </str:it_s_free>
         <str:website>
-            {%- if lang != config.default_language -%} {{ trans(key="website" | safe, lang=lang) }} {%- else -%} website {%- endif -%}
+            {{- macros_translate::translate(key="website", default="website") -}}
         </str:website>
         <str:recent_posts>
-            {%- if lang != config.default_language -%} {{ trans(key="recent_posts" | safe, lang=lang) }} {%- else -%} Recent posts {%- endif -%}
+            {{- macros_translate::translate(key="recent_posts", default="Recent posts") -}}
         </str:recent_posts>
     </str:translations>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,7 @@
 {% import "macros/set_title.html" as macros_set_title %}
 {% import "macros/settings.html" as macros_settings %}
 {% import "macros/table_of_contents.html" as macros_toc %}
+{% import "macros/translate.html" as macros_translate %}
 
 <!DOCTYPE html>
 <html lang="{{ lang }}" {% if config.extra.default_theme -%}

--- a/templates/macros/add_comments.html
+++ b/templates/macros/add_comments.html
@@ -86,7 +86,7 @@
 {% if automatic_loading %}
     <script src="{{ get_url(path='js/' ~ comment_system ~ '.min.js', trailing_slash=false) | safe }}" async></script>
 {% else %}
-    <button id="load-comments" class="load-comments-button" data-script-src="{{ get_url(path='js/' ~ comment_system ~ '.min.js', trailing_slash=false) | safe }}">{%- if lang != config.default_language %} {{ trans(key="load_comments" | safe, lang=lang) }}{% else %} Load comments {%- endif -%}</button>
+    <button id="load-comments" class="load-comments-button" data-script-src="{{ get_url(path='js/' ~ comment_system ~ '.min.js', trailing_slash=false) | safe }}">{{ macros_translate::translate(key="load_comments", default="Load comments") }}</button>
     <script src="{{ get_url(path='js/loadComments.min.js', trailing_slash=false) | safe }}" async></script>
 {% endif %}
 

--- a/templates/macros/content.html
+++ b/templates/macros/content.html
@@ -54,7 +54,7 @@
 
         <ul class="meta">
             {% if page.draft %}
-                <li class="draft-label">{%- if lang != config.default_language %} {{ trans(key="draft" | safe, lang=lang) }} {% else %} DRAFT {% endif %}</li>
+                <li class="draft-label">{{ macros_translate::translate(key="draft", default="DRAFT") }}</li>
             {% endif %}
 
             {% if page.date %}
@@ -63,25 +63,26 @@
 
             {# page settings override config settings #}
             {% if macros_settings::evaluate_setting_priority(setting="show_reading_time", page=page, default_global_value=true) == "true" %}
-                {{ separator }} <li title="{{ page.word_count }} {%- if lang != config.default_language %} {{ trans(key="words" | safe, lang=lang) }} {% else %} words {% endif %}">{{ page.reading_time }}{%- if lang != config.default_language %} {{ trans(key="min_read" | safe, lang=lang) }} {% else %} min read {% endif %}</li>
+                {{ separator }} <li title="{{ page.word_count }} {{ macros_translate::translate(key="words", default="words") }}">{{ page.reading_time }}&nbsp;{{ macros_translate::translate(key="min_read", default="min read") }}</li>
             {% endif %}
 
-            {% if page.taxonomies and page.taxonomies.tags %}
-                <li>&nbsp;{{ separator }}&nbsp;{%- if lang != config.default_language -%}{{ trans(key="tags" | safe, lang=lang) | capitalize }}{% else %}Tags{%- endif -%}:&nbsp;</li>
-                {% for tag in page.taxonomies.tags %}
+            {%- if page.taxonomies and page.taxonomies.tags -%}
+                {{ separator }}&nbsp;<li>{{- macros_translate::translate(key="tags", default="tags") | capitalize -}}:&nbsp;</li>
+                {%- for tag in page.taxonomies.tags -%}
                     <li><a href={{ get_taxonomy_url(kind='tags', name=tag, lang=lang) | safe }}>{{ tag }}</a>
                     {%- if not loop.last -%}
                         ,&nbsp;
                     {%- endif -%}
                     </li>
-                {% endfor %}
-            {% endif %}
+                {%- endfor -%}
+            {%- endif -%}
 
             {% if page.updated %}
-                </ul><ul class="meta last-updated"><li>{%- if lang != config.default_language %} {{ trans(key="last_updated_on" | safe, lang=lang) }} {% else %} Last updated on {% endif %} {{ macros_format_date::format_date(date=page.updated, short=true) }}</li>
+                </ul><ul class="meta last-updated"><li>{{ macros_translate::translate(key="last_updated_on", default="Last updated on") }} {{ macros_format_date::format_date(date=page.updated, short=true) }}</li>
                 {# Show link to remote changes if enabled #}
                 {% if config.extra.remote_repository_url and macros_settings::evaluate_setting_priority(setting="show_remote_changes", page=page, default_global_value=true) == "true" %}
-                    <li>&nbsp;{{ separator }}&nbsp;<a href="{{ macros_create_history_url::create_history_url(relative_path=page.relative_path) }}" {{ blank_target }} rel="{{ rel_attributes }}">{%- if lang != config.default_language -%}{{ trans(key="see_changes" | safe, lang=lang) }}{% else %}See changes{%- endif -%}<small> ↗</small></a></li>
+                    {{ separator }}
+                    <li><a href="{{ macros_create_history_url::create_history_url(relative_path=page.relative_path) }}" {{ blank_target }} rel="{{ rel_attributes }}">{{ macros_translate::translate(key="see_changes", default="See changes") }}<small> ↗</small></a></li>
                 {% endif %}
             {% endif %}
         </ul>

--- a/templates/macros/format_date.html
+++ b/templates/macros/format_date.html
@@ -1,11 +1,7 @@
 {% macro format_date(date, short) %}
 
 {# Set locale #}
-{%- if lang != config.default_language %}
-    {% set date_locale = trans(key="date_locale" | safe, lang=lang) %}
-{% else %}
-    {% set date_locale = "en_GB" %}
-{% endif %}
+{% set date_locale = macros_translate::translate(key="date_locale", default="en_GB") %}
 
 {% if config.extra.short_date_format and short %}
     {{ date | date(format=config.extra.short_date_format, locale=date_locale) }}

--- a/templates/macros/list_posts.html
+++ b/templates/macros/list_posts.html
@@ -37,15 +37,14 @@
                         <p>{{ post.summary | striptags | safe | trim_end_matches(pat=".") }}…</p>
                     {% endif %}
                 </div>
-
-                <a class="readmore" href={{ post.permalink }}>{%- if lang != config.default_language %} {{ trans(key="read_more" | safe, lang=lang) }} {% else %} Read more {% endif %}→</a>
+                <a class="readmore" href={{ post.permalink }}>{{ macros_translate::translate(key="read_more", default="Read more") }}&nbsp;→</a>
             </div>
         </section>
     {% endif %}
         {% if not loop.last %}
             {% if loop.index == max %}
                 <div class="all-posts">
-                    <a href="{{ get_url(path="blog", lang=lang) }}/">{%- if lang != config.default_language %} {{ trans(key="all_posts" | safe, lang=lang) }} {% else %} All posts {% endif %}⟶</a>
+                    <a href="{{ get_url(path="blog", lang=lang) }}/">{{ macros_translate::translate(key="all_posts", default="All posts") }}&nbsp;⟶</a>
                 </div>
             {% endif %}
         {% endif %}

--- a/templates/macros/paginate.html
+++ b/templates/macros/paginate.html
@@ -4,25 +4,25 @@
     <ul class="pagination">
         {% if paginator.previous %}
             <li class="page-item page-prev">
-                <a href="{{ paginator.previous }}" class="page-link" aria-label="{%- if lang != config.default_language %} {{ trans(key="prev" | safe, lang=lang) }}{% else %} Prev {%- endif -%}">← {%- if lang != config.default_language %} {{ trans(key="prev" | safe, lang=lang) }}{% else %} Prev {%- endif -%}</a>
+                <a href="{{ paginator.previous }}" class="page-link" aria-label="{{ macros_translate::translate(key="prev", default="Prev") }}">← {{ macros_translate::translate(key="prev", default="Prev") }}</a>
             </li>
         {% else %}
             <li class="page-item page-prev">
-                <span class="page-link disabled" aria-disabled="true" aria-label="{%- if lang != config.default_language %} {{ trans(key="prev" | safe, lang=lang) }}{% else %} Prev {%- endif -%} (disabled)">← {%- if lang != config.default_language %} {{ trans(key="prev" | safe, lang=lang) }}{% else %} Prev {%- endif -%}</span>
+                <span class="page-link disabled" aria-disabled="true" aria-label="{{ macros_translate::translate(key="prev", default="Prev") }} (disabled)">← {{ macros_translate::translate(key="prev", default="Prev") }}</span>
             </li>
         {% endif %}
 
         <li class="page-item page-numbers">
-            {{ paginator.current_index }} {%- if lang != config.default_language %} {{ trans(key="of" | safe, lang=lang) }}{% else %} of {%- endif %} {{ paginator.number_pagers }}
+            {{ paginator.current_index }} {{ macros_translate::translate(key="of", default="of") }} {{ paginator.number_pagers }}
         </li>
 
         {% if paginator.next %}
             <li class="page-item page-next">
-                <a href="{{ paginator.next }}" class="page-link" aria-label="{%- if lang != config.default_language %} {{ trans(key="next" | safe, lang=lang) }}{% else %} Next {%- endif -%}">{%- if lang != config.default_language %} {{ trans(key="next" | safe, lang=lang) }}{% else %} Next {%- endif %} →</a>
+                <a href="{{ paginator.next }}" class="page-link" aria-label="{{ macros_translate::translate(key="next", default="Next") }}">{{ macros_translate::translate(key="next", default="Next") }} →</a>
             </li>
         {% else %}
             <li class="page-item page-next">
-                <span class="page-link disabled" aria-disabled="true" aria-label="{%- if lang != config.default_language %} {{ trans(key="next" | safe, lang=lang) }}{% else %} Next {%- endif -%} (disabled)">{%- if lang != config.default_language %} {{ trans(key="next" | safe, lang=lang) }}{% else %} Next {%- endif %} →</span>
+                <span class="page-link disabled" aria-disabled="true" aria-label="{{ macros_translate::translate(key="next", default="Next") }} (disabled)">{{ macros_translate::translate(key="next", default="Next") }} →</span>
             </li>
         {% endif %}
     </ul>

--- a/templates/macros/set_title.html
+++ b/templates/macros/set_title.html
@@ -26,11 +26,7 @@
     {%- set suffix = term.name -%}
 {% elif taxonomy.name %}
     {# List of tags. #}
-    {%- if lang != config.default_language -%}
-        {%- set suffix = trans(key=taxonomy.name | safe, lang=lang) | capitalize -%}
-    {% else %}
-        {%- set suffix = taxonomy.name | capitalize -%}
-    {% endif %}
+    {%- set suffix = macros_translate::translate(key=taxonomy.name) | capitalize -%}
 {% else %}
     {%- set suffix = "404" %}
 {%- endif -%}

--- a/templates/macros/table_of_contents.html
+++ b/templates/macros/table_of_contents.html
@@ -8,7 +8,7 @@
 
 <div class="toc-container">
     {% if header %}
-        <h3>{%- if lang != config.default_language %} {{ trans(key="table_of_contents" | safe, lang=lang) }} {% else %} Table of Contents {% endif %}</h3>
+        <h3>{{ macros_translate::translate(key="table_of_contents", default="Table of Contents") }}</h3>
     {% endif %}
 
     <ul>

--- a/templates/macros/translate.html
+++ b/templates/macros/translate.html
@@ -1,0 +1,14 @@
+{% macro translate(key, default="", force_lang="") %}
+
+{%- if config.default_language != "en" -%}
+    {#- The entire site should be translated -#}
+    {{- trans(key=key | safe, lang=lang) -}}
+{%- elif lang != config.default_language -%} 
+    {{- trans(key=key | safe, lang=lang) -}}
+{%- elif force_lang -%}
+    {{- trans(key=key | safe, lang=force_lang) -}}
+{%- else -%} 
+    {{- default -}}
+{%- endif -%} 
+
+{% endmacro %}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -64,36 +64,24 @@
                 {%- if config.extra.copyright -%}
                     {% set current_year = now() | date(format="%Y") %}
                     {# Translate the copyright if set in the config #}
-                    {%- if config.extra.translate_copyright and lang != config.default_language -%} 
-                        <p>{{ trans(key="copyright", lang=lang) | replace(from="$CURRENT_YEAR", to=current_year) | replace(from="$SEPARATOR", to=separator) | markdown | safe }}</p>
+                    {%- if config.extra.translate_copyright -%}
+                        <p>{{ macros_translate::translate(key="copyright", default=config.extra.copyright) | replace(from="$CURRENT_YEAR", to=current_year) | replace(from="$SEPARATOR", to=separator) | markdown | safe }}</p>
                     {%- else -%}
                         <p>{{ config.extra.copyright | replace(from="$CURRENT_YEAR", to=current_year) | replace(from="$SEPARATOR", to=separator) | markdown | safe }}</p>
                     {%- endif -%}
                 {%- endif -%}
 
                 {# Shows "Powered by Zola & tabi" notice #}
-                {%- if lang != config.default_language -%} 
-                    {{ trans(key="powered_by" | safe, lang=lang) }} 
-                {%- else -%} 
-                    Powered by
-                {%- endif -%} 
-                &nbsp;<a rel="{{ rel_attributes }}" {{ blank_target }} href="https://www.getzola.org">Zola</a>&nbsp;
-                {%- if lang != config.default_language -%}
-                    {{ trans(key="and" | safe, lang=lang) }} 
-                {%- else -%} 
-                    &
-                {%- endif -%} 
-                &nbsp;<a rel="{{ rel_attributes }}" {{ blank_target }} href="https://github.com/welpo/tabi">tabi</a>
+                {{ macros_translate::translate(key="powered_by", default="Powered by") }}
+                <a rel="{{ rel_attributes }}" {{ blank_target }} href="https://www.getzola.org">Zola</a>
+                {{ macros_translate::translate(key="and", default="&") }}
+                <a rel="{{ rel_attributes }}" {{ blank_target }} href="https://github.com/welpo/tabi">tabi</a>
 
                 {# Shows link to remote repository #}
                 {%- if config.extra.remote_repository_url and config.extra.show_remote_source | default(value=true) -%}
                 {{ separator }}
                     <a rel="{{ rel_attributes }}" {{ blank_target }} href="{{ config.extra.remote_repository_url }}">
-                        {%- if lang != config.default_language -%}
-                            {{ trans(key="site_source" | safe, lang=lang) }}
-                        {%- else -%}
-                            Site source
-                        {%- endif -%}
+                        {{ macros_translate::translate(key="site_source", default="Site source") }}
                     </a>
                 {%- endif -%}
             </small>

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -12,11 +12,7 @@
                             <li>
                                 {% set trailing_slash = menu.trailing_slash | default(value=true) %}
                                 <a class="nav-links no-hover-padding" href="{{ get_url(path=menu.url, lang=lang, trailing_slash=trailing_slash) }}"/>
-                                {%- if lang != config.default_language -%}
-                                    {{ trans(key=menu.name | safe, lang=lang) }}
-                                {%- else -%}
-                                    {{ menu.name | safe }}
-                                {%- endif -%}
+                                {{ macros_translate::translate(key=menu.name, default=menu.name) }}
                                 </a>
                             </li>
                         {% endfor %}
@@ -31,11 +27,7 @@
 
                                 {# Display the current language first in the dropdown #}
                                 <div class="dropdown-content">
-                                    {%- if lang != config.default_language %}
-                                        {{ trans(key="language_name" | safe, lang=lang) }}
-                                    {% else %}
-                                        {{ config.extra.language_name.en }}
-                                    {%- endif %}
+                                    {{ macros_translate::translate(key="language_name", default=config.extra.language_name.en) }}
 
                                     {# Loop through all the available languages in the config #}
                                     {%- for lcode, language_name in config.extra.language_name -%}

--- a/templates/shortcodes/multilingual_quote.html
+++ b/templates/shortcodes/multilingual_quote.html
@@ -1,15 +1,12 @@
-{%- if lang != config.default_language -%}
-    {%- set open_quote = trans(key="open_quotation_mark" | safe, lang=lang) -%}
-    {%- set close_quote = trans(key="close_quotation_mark" | safe, lang=lang) -%}
-{%- else -%}
-    {%- set open_quote = "“" -%}
-    {%- set close_quote = "”" -%}
-{%- endif -%}
+{%- import "macros/translate.html" as macros_translate -%}
 
-{# The `random_id` ensures that each instance of the shortcode has a "unique" id #}
-{# allowing individual interactive elements (like toggles) to function correctly. #}
-{# This avoids conflicts when multiple instances of the shortcode are used. #}
-{# More context: https://github.com/welpo/tabi/issues/82 #}
+{%- set open_quote = macros_translate::translate(key="open_quotation_mark", default="“") -%}
+{%- set close_quote = macros_translate::translate(key="close_quotation_mark", default="”") -%}
+
+{#- The `random_id` ensures that each instance of the shortcode has a "unique" id -#}
+{#- allowing individual interactive elements (like toggles) to function correctly. -#}
+{#- This avoids conflicts when multiple instances of the shortcode are used. -#}
+{#- More context: https://github.com/welpo/tabi/issues/82 -#}
 {%- set random_id = get_random(end=100000) -%}
 
 <div class="quote-container">
@@ -19,22 +16,15 @@
             <blockquote>
                 <p>{{ open_quote ~ translated ~ close_quote }}</p>
                 <p> — {{ author }} <label for="toggle-{{ random_id }}" class="quote-label quote-label-original">
-                    ({%- if lang != config.default_language -%}
-                        {{ trans(key="show_original_quote" | safe, lang=lang) }}
-                    {%- else -%}
-                        Show original quote
-                    {%- endif -%})</label></p>
+                    ({{- macros_translate::translate(key="show_original_quote", default="Show original quote") -}})
+                    </label></p>
             </blockquote>
         </div>
         <div class="original">
             <blockquote>
                 <p>{{ open_quote ~ original ~ close_quote }}</p>
                 <p> — {{ author }} <label for="toggle-{{ random_id }}" class="quote-label quote-label-translate">
-                    ({%- if lang != config.default_language -%}
-                        {{ trans(key="show_translation" | safe, lang=lang) }}
-                    {%- else -%}
-                        Show translation
-                    {%- endif -%})
+                    ({{- macros_translate::translate(key="show_translation", default="Show translation") -}})
                 </label></p>            
             </blockquote>
         </div>

--- a/templates/tags/list.html
+++ b/templates/tags/list.html
@@ -2,11 +2,7 @@
 
 {% block main_content %}
 
-{%- if lang != config.default_language %}
-    {% set title = trans(key="tags_title" | safe, lang=lang) %}
-{% else %}
-    {% set title = "All tags" %}
-{% endif %}
+{%- set title = macros_translate::translate(key="tags_title", default="All tags") -%}
 
 {{ macros_page_header::page_header(title=title)}}
 
@@ -17,10 +13,10 @@
                 {{ term.name }}</a>
                 – {{ term.pages | length }}{%- if term.pages | length == 1 %}
                 {# Only one post. Singular. #}
-                    {%- if lang != config.default_language %} {{ trans(key="post" | safe, lang=lang) }}{% else %} post {%- endif -%}
+                    {{- macros_translate::translate(key="post", default="post") -}}
                 {% elif term.pages | length > 1 %}
                 {# More than one post per tag. Plural. #}
-                    {%- if lang != config.default_language %} {{ trans(key="posts" | safe, lang=lang) }}{% else %} posts {%- endif -%}
+                    {{- macros_translate::translate(key="posts", default="posts") -}}
                 {%- endif -%}
             </li>
         {%- endfor -%}

--- a/templates/tags/single.html
+++ b/templates/tags/single.html
@@ -9,7 +9,7 @@
 
 <ul class="pagination">
     <li class="page-item">
-        <a class="all-tags" href="{{ get_url(path="tags", lang=lang) }}/">← {%- if lang != config.default_language %} {{ trans(key="all_tags" | safe, lang=lang) }}{% else %} All tags {%- endif -%}</a>
+        <a class="all-tags" href="{{ get_url(path="tags", lang=lang) }}/">←&nbsp;{{- macros_translate::translate(key="all_tags", default="All tags") -}}</a>
     </li>
 </ul>
 


### PR DESCRIPTION
<details>
  <summary><strong>TL;DR</strong></summary>
  Refactored translation logic by using a new `translate.html` macro. 
</details>

### Summary

This PR overhauls the entire translation code in the templates, replacing a verbose and repetitive `if-else` conditional approach with a more streamlined macro-based solution. 

### Changes 

- Created the `translate.html` macro to handle translation logic.
- Modified all instances of the old `if-else` ([example](https://github.com/welpo/tabi/blob/3344f80539d837df10523160083d91c55b04f58f/templates/partials/nav.html#L14-L19)) translation blocks in Tera templates.
- Centralizes translation logic, making it easier to manage and extend.

### Benefits

- **Readability**: The new macro improves the readability of the templates.
- **Maintainability**: Future translation changes or additions are simplified.
- **Reusability**: The macro can be reused in different parts of the project, ensuring consistent behavior.

There should be no changes on the built sites before and after this PR[^1]. I hope I'm not wrong.

[^1]: Except this PR also fixes a minor spacing issue in the meta section of posts, where there would be extra spaces between sections if `minify_html` was not `true`.