### PR TITLE
🐛 fix(header): don't fail if custom_subset absent

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -20,7 +20,7 @@
     
     {# CSS #}
     {# Load subset of glyphs for header. Avoids flashing issue in Firefox #}
-    {% if config.extra.custom_subset == true %}
+    {% if config.extra.custom_subset and config.extra.custom_subset == true %}
         <link rel="stylesheet" href={{ get_url(path="custom_subset.css" ) }}>
     {% elif lang == 'en' %}
         <link rel="stylesheet" href={{ get_url(path="inter_subset_en.css" ) }}>


### PR DESCRIPTION
Following the install instructions on an empty zola project gives the following error:

```
Error: Failed to build the site
Error: Failed to render pager 1
Error: Reason: Failed to render 'index.html' (error happened in 'base.html').
Error: Reason: Variable `config.extra.custom_subset` not found in context while rendering 'partials/header.html'
```

Adding this config option to my `config.toml` fixes it, but the template should be resilient to that option being absent, like it does with other options.