### PR TITLE
✨ feat(title): add `invert_title_order` config option

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -219,6 +219,10 @@ short_date_format = ""
 # Custom separator used in title tag and posts metadata (between date, time to read, and tags).
 separator = "•"
 
+# Invert the order of the site title and page title in the browser tab.
+# Example: true => "Blog • ~/tabi", false => "~/tabi • Blog"
+invert_title_order = false
+
 # Full path after the base URL required. So if you were to place it in "static" it would be "/favicon.png"
 favicon = "img/seedling.png"
 

--- a/templates/macros/set_title.html
+++ b/templates/macros/set_title.html
@@ -32,6 +32,10 @@
 {%- endif -%}
 
 {# Return the final concatenated string. #}
-{{- prefix ~ separator ~ suffix -}}
+{%- if config.extra.invert_title_order -%}
+    {{- suffix ~ separator ~ prefix -}}
+{%- else -%}
+    {{- prefix ~ separator ~ suffix -}}
+{%- endif -%}
 
 {%- endmacro set_title -%}

--- a/theme.toml
+++ b/theme.toml
@@ -104,6 +104,10 @@ short_date_format = ""
 # Custom separator used in title tag and posts metadata (between date, time to read, and tags).
 separator = "•"
 
+# Invert the order of the site title and page title in the browser tab.
+# Example: true => "Blog • ~/tabi", false => "~/tabi • Blog"
+invert_title_order = false
+
 # Full path after the base URL required. So if you were to place it in "static" it would be "/favicon.ico"
 # favicon = ""
 


### PR DESCRIPTION
## Summary

This PR introduces a new configuration option `invert_title_order` that allows users to customize the order of the "site title" and "page title" in browser tabs.

## Linked issue

Resolves #135.

## Changes made

- Added `invert_title_order` boolean setting to `config.toml` and `theme.toml`.
- Modified `set_title.html` macro to incorporate the new `invert_title_order` setting.
- Updated `config.toml` and `theme.toml` documentation to explain the new feature.

## Reasoning

With longer site titles, the page title can sometimes be obscured when viewed in the browser tab. The new `invert_title_order` setting provides users with more flexibility by allowing the page title to be displayed before the site title. This improves the user experience by making the current page content more prominent when browsing between tabs.

## Example

The default title is formed like:
> ~/tabi • Secure by default

If the setting is `true`, the title would become:
> Secure by default • ~/tabi