### PR TITLE
✨ feat: add `browser_theme_color` config option

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -162,6 +162,12 @@ default_theme = "light"
 # All other skins have optimal contrast.
 skin = ""
 
+# Set browser theme colour. Can be a single colour or [light, dark]. 
+# Note: Bright colors may be ignored in dark mode.
+# More details: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color
+browser_theme_color = "#087e96"
+# browser_theme_color = ["#ffffff", "#000000"]  # Example of light/dark colours.
+
 # List additional stylesheets to load site-wide.
 # These stylesheets should be located in your site's `static` directory.
 # Example: stylesheets = ["extra1.css", "path/extra2.css"]

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -53,6 +53,15 @@
     
     <meta name="color-scheme" content="{%- if config.extra.theme_switcher -%}light dark{%- elif config.extra.default_theme -%}{{config.extra.default_theme}}{%- else -%}light{%- endif -%}" />
 
+    {%- if config.extra.browser_theme_color and config.extra.browser_theme_color is iterable -%}
+        {# Handle array values: theme_color[0] for light mode, theme_color[1] for dark mode #}
+        <meta name="theme-color" media="(prefers-color-scheme: light)" content="{{ config.extra.browser_theme_color[0] }}" />
+        <meta name="theme-color" media="(prefers-color-scheme: dark)" content="{{ config.extra.browser_theme_color[1] }}" />
+    {%- elif config.extra.browser_theme_color -%}
+        {# Handle single value #}
+        <meta name="theme-color" content="{{ config.extra.browser_theme_color }}" />
+    {%- endif -%}
+
     {%- if page.description %}
         <meta name="description" content="{{ page.description | striptags | safe }}" />
         <meta property="og:description" content="{{ page.description | striptags | safe }}" />

--- a/theme.toml
+++ b/theme.toml
@@ -47,6 +47,12 @@ default_theme = "light"
 # All other skins have optimal contrast.
 skin = ""
 
+# Set browser theme colour. Can be a single colour or [light, dark]. 
+# Note: Bright colors may be ignored in dark mode.
+# More details: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color
+# browser_theme_color = "#087e96"  # Example of single value.
+# browser_theme_color = ["#ffffff", "#000000"]  # Example of light/dark colours.
+
 # List additional stylesheets to load site-wide.
 # These stylesheets should be located in your site's `static` directory.
 # Example: stylesheets = ["extra1.css", "path/extra2.css"]


### PR DESCRIPTION
## Summary

This PR introduces a new configuration option, `browser_theme_color`, to set the browser's theme colour (see the [Mozilla Documentation on theme-color](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color)).

This option is flexible, allowing for either a single colour value or an array for light and dark modes.

## Linked Issue

Resolves #137.

## Changes Made

- Added a `browser_theme_color` option in `config.toml` and `theme.toml`.
- Implemented logic in Tera template to handle both single colour and array values.
  
## Features

- **Single Value**: Set a single colour that will be used universally across all browser modes.
  
  ```toml
  browser_theme_color = "#ffffff"
  ```
  
- **Array Value**: Use an array to specify different colours for light and dark modes.
  
  ```toml
  browser_theme_color = ["#ffffff", "#000000"]  # [light, dark]
  ```

## Screenshot

Notice how the top bar is coloured with the theme's main colour (`browser_theme_color = "#087e96"`):
  
![tabi](https://github.com/welpo/tabi/assets/6399341/ff3baa62-02b6-495b-b01c-9b28c022df84)

