### PR TITLE
✨ feat(alias): style redirect page

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -238,6 +238,17 @@ strong {
     text-align: center;
 }
 
+.center-content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+    width: 100%;
+    height: 100vh;
+    text-align: center;
+}
+
 .subheader {
     margin-bottom: 2rem;
 }

--- a/templates/internal/alias.html
+++ b/templates/internal/alias.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <link rel="canonical" href="{{ url | safe }}">
+    <link rel="stylesheet" href="{{ get_url(path="main.css", cachebust=true) | safe }}" />
+    <meta http-equiv="refresh" content="0; url={{ url | safe }}">
+    <title>Redirect</title>
+</head>
+<body class="center-content">
+    <h1><a href="{{ url | safe }}">Click here</a> to be redirected.</h1>
+</body>
+</html>


### PR DESCRIPTION
## Description

This PR adds basic styling to the alias / redirect page.

The `main.css` file will be loaded. The current style shows a larger text, fully centered on page, showing the redirection.

## Limitations

The `alias.html` template can't read the config, so custom CSS or skins won't be loaded. It's also impossible to add multilanguage support because of this.

## Screenshot

![Screenshot](https://github.com/welpo/tabi/assets/6399341/0ecf12b4-8a9d-4b84-9148-98fa4fa0f5e6)

## Issues

Resolves #149.
