### PR TITLE
🐛 fix(header): check if translations exist while building tags

### DIFF
--- a/templates/partials/multilingual_tags.html
+++ b/templates/partials/multilingual_tags.html
@@ -16,10 +16,16 @@
         {%- endif -%}
         {%- set translated_filename = translated_filename ~ ".md" -%}
 
-        {%- if page.relative_path -%}
-            {%- set translated_page = get_page(path=translated_filename) -%}
-        {%- else -%}
-            {%- set translated_page = get_section(path=translated_filename) -%}
+        {# Check if the translated page or section exists #}
+        {%- set translation_exists = load_data(path=translated_filename, required=false) -%}
+
+        {# Get the page #}
+        {%- if translation_exists -%}
+            {%- if page.relative_path -%}
+                {%- set translated_page = get_page(path=translated_filename, metadata_only=true) -%}
+            {%- else -%}
+                {%- set translated_page = get_section(path=translated_filename, metadata_only=true) -%}
+            {%- endif -%}
         {%- endif -%}
 
         {# Create the og:locale and hreflang tags if the translated page exists #}


### PR DESCRIPTION
## Description

This PR aims to resolves #158, the build-stopping bug when pages are missing translations for all config languages.

## Changes Made

1. Modified the Tera template to conditionally check for the existence of translated pages or sections before invoking `get_page` or `get_section`.
2. Utilised `load_data` with `required=false` as a workaround to check for the existence of a `.md` file, thus preventing build errors.

```tera
{# Check if the translated page or section exists #}
{%- set translation_exists = load_data(path=translated_filename, required=false) -%}

{# Get the page or section details #}
{%- if translation_exists -%}
    {%- if page.relative_path -%}
        {%- set translated_page = get_page(path=translated_filename, metadata_only=true) -%}
    {%- else -%}
        {%- set translated_page = get_section(path=translated_filename, metadata_only=true) -%}
    {%- endif -%}
{%- endif -%}
```

## Points to Consider

- The use of `load_data` here is primarily a workaround due to the lack of a direct function to check for file existence in Zola (see [this discussion](https://zola.discourse.group/t/function-to-check-if-a-file-exists/1767)). Therefore, this solution might not be the most idiomatic or efficient, but it serves the purpose of resolving the build-stopping issue.