### PR TITLE
✨ feat(social-media-cards): allow colocated paths

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -92,13 +92,32 @@
     {# Image for social media sharing #}
     {%- set social_media_card = macros_settings::evaluate_setting_priority(setting="social_media_card", page=page | default(value=""), section=section | default(value=""), default_global_value="") -%}
     {% if social_media_card %}
-        <meta property="og:image" content="{{ get_url(path=social_media_card, cachebust=true) }}" />
-        {%- set meta = get_image_metadata(path=social_media_card, allow_missing=true) -%}
-        {%- if meta -%}
-            <meta property="og:image:width" content="{{ meta.width }}" />
-            <meta property="og:image:height" content="{{ meta.height }}" />
-        {%- endif -%}
-        <meta name="twitter:image" content="{{ get_url(path=social_media_card, cachebust=true) }}" />
+        {# Try to construct the image path relative to the current page #}
+        {% set colocated_path = page.colocated_path | default(value="") %}
+        {% set file_path = colocated_path ~ social_media_card %}
+        
+        {# Fetch metadata to verify image existence at the relative path #}
+        {%- set meta = get_image_metadata(path=file_path, allow_missing=true) -%}
+        
+        {# Check if relative path exists, else try absolute path #}
+        {% if meta %}
+            {% set final_path = file_path %}
+        {% else %}
+            {# If the relative path didn't work, try fetching metadata for the absolute path #}
+            {% set meta = get_image_metadata(path=social_media_card, allow_missing=true) %}
+            {% if meta %}
+                {% set final_path = social_media_card %}
+            {% else %}
+                {# Throw an error if the image doesn't exist at either path #}
+                {{ throw(message="Could not get metadata for the specified social media card image in page " ~ page.path ~ ". Attempted relative path: '" ~ file_path ~ "' and absolute path: '" ~ social_media_card ~ "'. Ensure the file exists at one of these locations.") }}
+            {% endif %}
+        {% endif %}
+        
+        {# Generate the social media meta tags #}
+        <meta property="og:image" content="{{ get_url(path=final_path, cachebust=true) }}" />
+        <meta property="og:image:width" content="{{ meta.width }}" />
+        <meta property="og:image:height" content="{{ meta.height }}" />
+        <meta name="twitter:image" content="{{ get_url(path=final_path, cachebust=true) }}" />
         <meta name="twitter:card" content="summary_large_image" />
     {% endif %}
 


### PR DESCRIPTION
## Description

This PR adds the ability to specify relative paths for the `social_media_card` in a post. Useful for co-located assets in posts with a structure like:

```
/content/
    blog/
        post-folder/
            index.md
            social-media-card.jpg
        _index.md
```

In the example above, the social media card can now be set with `social_media_card = social-media-card.jpg` instead of its full path.

## New Features

- Support for relative paths for `social_media_card` based on the colocated folder.
- Detailed error messages to aid debugging when the image is not found.

## How Has This Been Tested?

- Manually tested the changes by creating posts with relative and absolute paths for the social media cards.
- Verified that appropriate error messages are shown when the image file does not exist at either of the specified paths.

## Additional Context

This feature was requested in Issue #161. 