### PR TITLE
✨ feat(atom): add `full_content_in_feed` option

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -147,6 +147,10 @@ menu = [
 # The RSS icon will be shown if (1) it's enabled and (2) the following variable is set to true.
 feed_icon = true
 
+# Show the full post content in the Atom feed.
+# If it's set to false, only the description or summary will be shown.
+full_content_in_feed = false
+
 # Email address for footer's social section.
 # Protect against spambots:
 # 1. Use base64 for email (convert at https://www.base64encode.org/ or `printf 'your@email.com' | base64`).

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -61,7 +61,9 @@
         </author>
         <link rel="alternate" href="{{ page.permalink | safe }}" type="text/html"/>
         <id>{{ page.permalink | safe }}</id>
-        {% if page.summary -%}
+        {% if config.extra.full_content_in_feed %}
+            <content type="html">{{ page.content | safe }}</content>
+        {% elif page.summary -%}
             <summary type="html">{{ page.summary | striptags | safe | trim_end_matches(pat=".") }}…</summary>
         {% elif page.description -%}
             <summary type="html">{{ page.description | striptags | safe }}</summary>

--- a/theme.toml
+++ b/theme.toml
@@ -130,6 +130,10 @@ menu = [
 # The RSS icon will be shown if (1) it's enabled and (2) the following variable is set to true.
 feed_icon = true
 
+# Show the full post content in the Atom feed.
+# If it's set to false, only the description or summary will be shown.
+full_content_in_feed = false
+
 # Email address for footer's social section.
 # Protect against spambots:
 # 1. Use base64 for email (convert at https://www.base64encode.org/ or `printf 'your@email.com' | base64`).


### PR DESCRIPTION
## Summary

This PR adds the ability to include the entire `page.content` in `atom.xml` if the optional `full_content_in_feed` is set to `true`.

Resolves #160.

## Changes
- Modified `atom.xml` Tera template to conditionally include `<content>` tag based on `config.extra.full_content_in_feed` flag.
- Added documentation in the form of comments for this new feature.
  
## How to test
Enable `full_content_in_feed` in your site's configuration and observe `atom.xml` through an RSS reader. It should display the full content of the page.