### PR TITLE
🐛 fix(atom): remove safe filter on page.content, and don't make content and summary mutually exclusive

### DIFF
--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -62,7 +62,7 @@
         <link rel="alternate" href="{{ page.permalink | safe }}" type="text/html"/>
         <id>{{ page.permalink | safe }}</id>
         {% if config.extra.full_content_in_feed %}
-            <content type="html">{{ page.content | safe }}</content>
+            <content type="html">{{ page.content }}</content>
         {% elif page.summary -%}
             <summary type="html">{{ page.summary | striptags | safe | trim_end_matches(pat=".") }}…</summary>
         {% elif page.description -%}

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -63,7 +63,8 @@
         <id>{{ page.permalink | safe }}</id>
         {% if config.extra.full_content_in_feed %}
             <content type="html">{{ page.content }}</content>
-        {% elif page.summary -%}
+        {% endif -%}
+        {% if page.summary -%}
             <summary type="html">{{ page.summary | striptags | safe | trim_end_matches(pat=".") }}…</summary>
         {% elif page.description -%}
             <summary type="html">{{ page.description | striptags | safe }}</summary>


### PR DESCRIPTION
# Summary

### Commit A:

This fixes broken atom feed which shows the following when there is `<br>` tag on one of the blog:

![image](https://github.com/welpo/tabi/assets/64297935/f62e3544-f242-4eb8-8e23-27d9a093ceb2)

### Commit B:

This makes summary and content tag be able to coexist.

# Changes

### Commit A:

This removes the `| safe` filter on <content> in `atom.xml`.

### Commit B:

This puts the summary tag in a separate if statement from the content tag.