### PR TITLE
✨ feat(header): add support for canonical URLs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -68,6 +68,12 @@ browser_theme_color = "#087e96"
 # You can load a stylesheet for a single post by adding it to the [extra] section of the post's front matter, following this same format.
 stylesheets = []
 
+# Sets the default canonical URL for all pages.
+# Individual pages can override this in the [extra] section using canonical_url.
+# Example: "$base_url/blog/post1" will get the canonical URL "https://example.com/blog/post1".
+# Note: To ensure accuracy in terms of matching content, consider setting 'canonical_url' individually per page.
+# base_canonical_url = "https://example.com"
+
 # Remote repository for your Zola site.
 # Used for `show_remote_changes` and `show_remote_source` (see below).
 # Supports GitHub, GitLab, Gitea, and Codeberg.

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -82,13 +82,6 @@
     <meta property="og:title" content="{{ page.title | default(value=config.title) | safe }}" />
     <meta property="og:type" content="article" />
 
-    {# Add og:locale and hreflang tags for multilingual sites #}
-    {%- if config.languages | length > 0 and current_url %}
-        {%- include "partials/multilingual_tags.html" -%}
-    {%- else -%}
-        <meta property="og:locale" content="{{ macros_translate::translate(key="date_locale", default="en_GB", language_strings=language_strings) }}" />
-    {%- endif %}
-
     {# Image for social media sharing #}
     {%- set social_media_card = macros_settings::evaluate_setting_priority(setting="social_media_card", page=page | default(value=""), section=section | default(value=""), default_global_value="") -%}
     {% if social_media_card %}
@@ -102,8 +95,28 @@
         <meta name="twitter:card" content="summary_large_image" />
     {% endif %}
 
+    {# Add og:locale and hreflang tags for multilingual sites #}
+    {%- if config.languages | length > 0 and current_url %}
+        {%- include "partials/multilingual_tags.html" -%}
+    {%- else -%}
+        <meta property="og:locale" content="{{ macros_translate::translate(key="date_locale", default="en_GB", language_strings=language_strings) }}" />
+    {%- endif %}
+
+    {# Set canonical URL #}
     {%- if current_url -%}
-        <meta property="og:url" content="{{ current_url }}">
+        {%- if page.extra.canonical_url or section.extra.canonical_url -%}
+            {%- set canonical_url = page.extra.canonical_url | default(value=section.extra.canonical_url) -%}
+        {%- elif config.extra.base_canonical_url -%}
+            {%- set canonical_url = current_url | replace(from=config.base_url, to=config.extra.base_canonical_url) -%}
+        {%- endif -%}
+    {%- endif -%}
+    
+    {# Add canonical URL, if set #}
+    {%- if canonical_url -%}
+        <link rel="canonical" href="{{ canonical_url }}" />
+        <meta property="og:url" content="{{ canonical_url }}" />
+    {%- elif current_url -%}
+        <meta property="og:url" content="{{ current_url }}" />
     {%- endif -%}
     
     <meta property="og:site_name" content="{{ config.title }}">

--- a/theme.toml
+++ b/theme.toml
@@ -51,6 +51,12 @@ skin = ""
 # You can load a stylesheet for a single post by adding it to the [extra] section of the post's front matter, following this same format.
 stylesheets = []
 
+# Sets the default canonical URL for all pages.
+# Individual pages can override this in the [extra] section using canonical_url.
+# Example: "$base_url/blog/post1" will get the canonical URL "https://example.com/blog/post1".
+# Note: To ensure accuracy in terms of matching content, consider setting 'canonical_url' individually per page.
+# base_canonical_url = "https://example.com"
+
 # Remote repository for your Zola site.
 # Used for `show_remote_changes` and `show_remote_source` (see below).
 # Supports GitHub, GitLab, Gitea, and Codeberg.


### PR DESCRIPTION
## Description

This PR enhances tabi's SEO capabilities by introducing a flexible system for setting canonical URLs.

The feature allows for setting canonical URLs at individual page or section levels, with a fallback to a dynamically generated global `base_canonical_url`, if specified.

Resolves #151.

## Changes

- Added `canonical_url` as an optional front matter attribute in both pages and sections under the `[extra]` section.
- Introduced a dynamic fallback mechanism that crafts the canonical URL by replacing the `$base_url` in the current URL with the `base_canonical_url` specified in `config.toml`.
- Updated HTML templates to conditionally include `<link rel="canonical">` and `<meta property="og:url">` based on the newly introduced logic.

## How to Test

1. Add `canonical_url` to the `[extra]` section of a page or section's front matter.
    ```toml
    [extra]
    canonical_url = "https://example.com/custom-canonical-url"
    ```
2. Alternatively, set a dynamic global `base_canonical_url` in `config.toml`.
    ```toml
    base_canonical_url = "https://example.com"
    ```
3. Build the site and verify that the canonical URLs in the HTML headers are set as expected.

## Additional Information

This feature is beneficial for those running multiple domains with the same content. By setting `base_canonical_url` dynamically, it will automatically adapt the canonical URLs based on the current URL's `$base_url`. For example, for a page with URL `$base_url/blog/post1`, and a `base_canonical_url` set to "https://example.com", the generated canonical URL will be "https://example.com/blog/post1".