### PR TITLE
🐛 fix(html): Remove unused self-closing tags

### DIFF
--- a/templates/partials/extra_features.html
+++ b/templates/partials/extra_features.html
@@ -37,10 +37,10 @@
 
 {# Add copy button to code blocks #}
 {%- if macros_settings::evaluate_setting_priority(setting="copy_button", page=page, default_global_value=true) == "true" -%}
-    <script defer src="{{ get_url(path='js/copyCodeToClipboard.min.js', trailing_slash=false) | safe }}"/></script>
+    <script defer src="{{ get_url(path='js/copyCodeToClipboard.min.js', trailing_slash=false) | safe }}"></script>
 {%- endif -%}
 
 {# Add backlinks to footnotes #}
 {%- if macros_settings::evaluate_setting_priority(setting="footnote_backlinks", page=page, default_global_value=false) == "true" -%}
-    <script defer src="{{ get_url(path='js/footnoteBacklinks.min.js', trailing_slash=false | safe )}}"/></script>
+    <script defer src="{{ get_url(path='js/footnoteBacklinks.min.js', trailing_slash=false | safe )}}"></script>
 {%- endif -%}

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -11,7 +11,7 @@
                         {% for menu in config.extra.menu %}
                             <li>
                                 {% set trailing_slash = menu.trailing_slash | default(value=true) %}
-                                <a class="nav-links no-hover-padding" href="{{ get_url(path=menu.url, lang=lang, trailing_slash=trailing_slash) }}"/>
+                                <a class="nav-links no-hover-padding" href="{{ get_url(path=menu.url, lang=lang, trailing_slash=trailing_slash) }}">
                                 {{ macros_translate::translate(key=menu.name, default=menu.name, language_strings=language_strings) }}
                                 </a>
                             </li>


### PR DESCRIPTION
Noticed a self-closing `a` tag and grepped the source for other unnecessary self-closing tags.