### PR TITLE
♻️ refactor(HTML): remove X-UA-Compatible

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -1,6 +1,5 @@
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     {# Site title #}


### PR DESCRIPTION
It [hasn't been necessary](https://stackoverflow.com/questions/26346917/why-use-x-ua-compatible-ie-edge-anymore) for a number of years now and the [JavaScript files](https://github.com/welpo/tabi/blob/93eaaea76c01ba18b05113778d11131bec0d3b92/static/js/copyCodeToClipboard.js#L28) target [modern browsers](https://caniuse.com/mdn-javascript_operators_nullish_coalescing) anyway.