### PR TITLE
🐛 fix(analytics): make goatcounter use https

### DIFF
--- a/templates/partials/analytics.html
+++ b/templates/partials/analytics.html
@@ -9,7 +9,7 @@
         src="{{ self_hosted_url ~ '/count.js' }}"
     {% else %}
         data-goatcounter="https://{{ analytics_id }}.goatcounter.com/count" 
-        src="//gc.zgo.at/count.js"
+        src="https://gc.zgo.at/count.js"
         {% endif %}
     ></script>
 


### PR DESCRIPTION
without explicitly defining `https://` it will default to using http instead