### PR TITLE
✨ feat: add content support to cards template

### DIFF
--- a/templates/cards.html
+++ b/templates/cards.html
@@ -8,6 +8,10 @@
     {{ macros_page_header::page_header(title=section.title) }}
 
     <main>
+        {% if section.content -%}
+            <div id="page-content">{{ section.content | safe }}</div>
+        {% endif %}
+
         {%- if paginator %}
             {%- set show_pages = paginator.pages -%}
         {% else %}


### PR DESCRIPTION
This PR lets users add optional content to cards pages, useful to write a short description about a given page.