### PR TITLE
💄 fix(style): limit width of .toc-container

### DIFF
--- a/sass/parts/_quick_navigation_buttons.scss
+++ b/sass/parts/_quick_navigation_buttons.scss
@@ -55,6 +55,7 @@
         .toc-container {
             margin: 0;
             margin-top: $padding-vertical;
+            max-width: 80vw;
         }
 
         .toc-content {


### PR DESCRIPTION
Fixes an issue where the table of contents popup would overflow with long headings and small viewports.