### PR TITLE
💄 fix(style): add line-height to .section-title

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -155,9 +155,11 @@ article {
 .section-title {
     display: block;
     margin: 0;
+    margin-top: -0.15em;
     color: var(--text-color-high-contrast);
     font-weight: 550;
     font-size: 2.2em;
+    line-height: 1.2em;
 }
 
 .last-updated {

--- a/sass/parts/_misc.scss
+++ b/sass/parts/_misc.scss
@@ -38,7 +38,7 @@ ul {
 }
 
 .title-container {
-    padding-bottom: 15px;
+    padding-bottom: 8px;
 }
 
 .bottom-divider {


### PR DESCRIPTION
Fixes an issue where section titles with multiple lines would be very close to each other. Other values are changed so single-line spacing is roughly the same.