### PR TITLE
🐛 fix(stylised-feed): set proper date class

### DIFF
--- a/static/feed_style.xsl
+++ b/static/feed_style.xsl
@@ -51,9 +51,9 @@
             <div class="bloglist-container">
               <xsl:for-each select="/atom:feed/atom:entry">
                 <section class="bloglist-row bottom-divider">
-                  <div class="date">
-                    <xsl:value-of select="substring(atom:published, 0, 11)"/>
-                  </div>
+                  <ul class="bloglist-meta">
+                    <li class="date"><xsl:value-of select="substring(atom:published, 0, 11)"/></li>
+                  </ul>
                   <div class="bloglist-content">
                     <div class="bloglist-title">
                       <a>


### PR DESCRIPTION
Fixes #206 by applying the new `bloglist-meta` label (and ul/li structure) —introduced in #203— to the stylised feed's date.