### PR TITLE
🐛 fix(comments): fix malformed URLs in Isso mails

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -283,7 +283,7 @@ lazy_loading = true
 enabled_for_all_posts = false  # Enables Isso on all posts. It can be enabled on individual posts by setting `isso = true` in the [extra] section of a post's front matter.
 automatic_loading = true  # If set to false, a "Load comments" button will be shown.
 endpoint_url = ""  # Accepts relative paths like "/comments/" or "/isso/", as well as full urls like "https://example.com/comments/". Include the trailing slash.
-page_id_is_slug = true  # If true, it will use the post's filename (slug) as id; this is the only way to share comments between languages. If false, it will use the entire url as id.
+page_id_is_slug = true  # If true, it will use the relative path for the default language as id; this is the only way to share comments between languages. If false, it will use the entire url as id.
 lang = ""  # Leave blank to match the page's language.
 max_comments_top = "inf"  # Number of top level comments to show by default. If some comments are not shown, an “X Hidden” link is shown.
 max_comments_nested = "5"  # Number of nested comments to show by default. If some comments are not shown, an “X Hidden” link is shown.

--- a/templates/partials/comments.html
+++ b/templates/partials/comments.html
@@ -66,8 +66,9 @@
 {% elif comment_system == "isso" %}
     data-endpoint-url="{{ config.extra.isso.endpoint_url }}"
     {% if config.extra.isso.page_id_is_slug %}
-        data-isso-id="{{ page.slug }}"
-        data-title="{{ page.slug }}"
+    {%- set default_lang_url = current_path | replace(from='/' ~ lang ~ '/', to = '/') -%}
+        data-isso-id="{{ default_lang_url }}"
+        data-title="{{ default_lang_url }}"
     {% endif %}
     {% if config.extra.isso.lang  %}
         data-page-language="{{ config.extra.isso.lang }}"

--- a/theme.toml
+++ b/theme.toml
@@ -262,7 +262,7 @@ allowed_domains = [
 # enabled_for_all_posts = false  # Enables Isso on all posts. It can be enabled on individual posts by setting `isso = true` in the [extra] section of a post's front matter.
 # automatic_loading = true  # If set to false, a "Load comments" button will be shown.
 # endpoint_url = ""  # Accepts relative paths like "/comments/" or "/isso/", as well as full urls like "https://example.com/comments/". Include the trailing slash.
-# page_id_is_slug = true  # If true, it will use the post's filename (slug) as id; this is the only way to share comments between languages. If false, it will use the entire url as id.
+# page_id_is_slug = true  # If true, it will use the relative path for the default language as id; this is the only way to share comments between languages. If false, it will use the entire url as id.
 # lang = ""  # Leave blank to match the page's language.
 # max_comments_top = "inf"  # Number of top level comments to show by default. If some comments are not shown, an “X Hidden” link is shown.
 # max_comments_nested = "5"  # Number of nested comments to show by default. If some comments are not shown, an “X Hidden” link is shown.


### PR DESCRIPTION
## Description

This PR aims to address the issue of malformed URLs in the email notifications generated by Isso, as detailed in #210.

## Changes

- Modified the Tera template to change how `data-isso-id` and `data-title` are set.
  
## Implementation details

The previous setup used the page's slug to populate `data-isso-id` and `data-title`. This resulted in URLs lacking a separating slash between the domain and the identifier/post in the email notifications.

The new setup uses `default_lang_url` in Tera templates to populate these attributes:

```tera
{%- set default_lang_url = current_path | replace(from='/' ~ lang ~ '/', to = '/') -%}
    data-isso-id="{{ default_lang_url }}"
    data-title="{{ default_lang_url }}"
{% endif %}
```

## Limitations

While this solution is effective for most use-cases, it's not perfect. Specifically, if a post does not exist in a non-default language, the URL in the email notification will still return 404. However, as far as I know, this is the only way to merge comments in multilingual sites effectively.

## Testing

1. Enable Isso comments on the site.
2. Enable email notifications in the Isso setup.
3. Configure `page_id_is_slug = true` in `[extra.isso]`.
4. Submit a comment.
5. Verify that the received email notification contains the correct and functional link to the comment.