### PR TITLE
feat(404): Split error statement from solution

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -9,7 +9,7 @@
     {%- if config.languages | length > 0 -%}
         &nbsp;{{ macros_translate::translate(key="translation_missing", default="or hasn't been translated into your language yet", force_lang=language_name, language_strings=language_strings) }}{{ macros_translate::translate(key="full_stop", default=".", force_lang=language_name, language_strings=language_strings) }}
     {%- else %}.
-    {%- endif %}
+    {%- endif %}<br>
     {{ macros_translate::translate(key="check_url", default="Check the URL for errors or", force_lang=language_name, language_strings=language_strings) }}
     <a href="{{ config.base_url }}{% if language_name != config.default_language %}/{{ language_name }}{% endif %}/">
     {{ macros_translate::translate(key="go_home", default="go back to the homepage", force_lang=language_name, language_strings=language_strings) }}</a>{{ macros_translate::translate(key="full_stop", default=".", force_lang=language_name, language_strings=language_strings) }}</p>


### PR DESCRIPTION
Adding a line break between error statement and proposed solution improves readability without reducing accessibility or responsiveness (or at least, I hope so).

Before:
![404_before](https://github.com/welpo/tabi/assets/89450172/cb85d34d-33b1-4849-a2c1-0aba719060a9)


After:
![404_after](https://github.com/welpo/tabi/assets/89450172/aead5a99-252f-4f6f-a798-6150c10c2b07)
