### PR TITLE
Set copyright translations outside toml files + enhance $VARs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -189,18 +189,16 @@ footer_menu = [
 
 # Enable a copyright notice for the footer, shown between socials and the "Powered by" text.
 # $TITLE will be replaced by the website's title.
-# You can use $CURRENT_YEAR to automatically insert the current year.
+# $CURRENT_YEAR will be replaced by the current year.
+# $AUTHOR will be replaced by the `author` variable.
 # $SEPARATOR will be replaced by the `separator` variable.
 # Markdown is supported (links, emphasis, etc).
-# copyright = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
+# copyright = "$TITLE © $CURRENT_YEAR $AUTHOR $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
 
 # For multi-language sites, you can set a different copyright for each language.
-# If this is set to true, ensure you have a translation in `copyright_translations` for each language.
-translate_copyright = false
-# If `translate_copyright` is set to true, `copyright_translations` can be empty but must exist.
-# A build time error will be raised otherwise in order to make sure people already using previous translation method (i18n files) won't forgot to move translations back in config.toml.
-# If a translation is missing for language, the `copyright` value will be used instead.
-# copyright_translations.es = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+# The old way of setting `translated_copyright = true` and using i18n files is deprecated.
+# If a translation is missing for language, the `copyright` value will be used.
+# copyright_translations.es = "$AUTHOR © $CURRENT_YEAR Tu Nombre $SEPARATOR A menos que se indique lo contrario, el contenido de esta web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
 
 # Custom security headers. What urls should your website be able to connect to?
 # You need to specify the CSP and the URLs associated with the directive.

--- a/config.toml
+++ b/config.toml
@@ -198,7 +198,7 @@ footer_menu = [
 # For multi-language sites, you can set a different copyright for each language.
 # The old way of setting `translated_copyright = true` and using i18n files is deprecated.
 # If a translation is missing for language, the `copyright` value will be used.
-# copyright_translations.es = "$AUTHOR © $CURRENT_YEAR Tu Nombre $SEPARATOR A menos que se indique lo contrario, el contenido de esta web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+# copyright_translations.es = "$TITLE © $CURRENT_YEAR $AUTHOR $SEPARATOR A menos que se indique lo contrario, el contenido de esta web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
 
 # Custom security headers. What urls should your website be able to connect to?
 # You need to specify the CSP and the URLs associated with the directive.

--- a/config.toml
+++ b/config.toml
@@ -188,10 +188,11 @@ footer_menu = [
 ]
 
 # Enable a copyright notice for the footer, shown between socials and the "Powered by" text.
+# $TITLE will be replaced by the website's title.
 # You can use $CURRENT_YEAR to automatically insert the current year.
 # $SEPARATOR will be replaced by the `separator` variable.
 # Markdown is supported (links, emphasis, etc).
-# copyright = "© $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
+# copyright = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
 
 # For multi-language sites, you can set a different copyright for each language.
 # If this is set to true, ensure you have a translation in `copyright_translations` for each language.
@@ -199,7 +200,7 @@ translate_copyright = false
 # If `translate_copyright` is set to true, `copyright_translations` can be empty but must exist.
 # A build time error will be raised otherwise in order to make sure people already using previous translation method (i18n files) won't forgot to move translations back in config.toml.
 # If a translation is missing for language, the `copyright` value will be used instead.
-# copyright_translations.es = "© $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+# copyright_translations.es = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
 
 # Custom security headers. What urls should your website be able to connect to?
 # You need to specify the CSP and the URLs associated with the directive.

--- a/config.toml
+++ b/config.toml
@@ -194,8 +194,12 @@ footer_menu = [
 # copyright = "© $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
 
 # For multi-language sites, you can set a different copyright for each language.
-# If this is set to true, ensure you have a `copyright` translation for each language.
+# If this is set to true, ensure you have a translation in `copyright_translations` for each language.
 translate_copyright = false
+# If `translate_copyright` is set to true, `copyright_translations` can be empty but must exist.
+# A build time error will be raised otherwise in order to make sure people already using previous translation method (i18n files) won't forgot to move translations back in config.toml.
+# If a translation is missing for language, the `copyright` value will be used instead.
+# copyright_translations.es = "© $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
 
 # Custom security headers. What urls should your website be able to connect to?
 # You need to specify the CSP and the URLs associated with the directive.

--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -554,7 +554,11 @@ copyright = "© $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the c
 Si tens un lloc multilingüe i vols establir diferents notificacions de drets d'autor per a diferents idiomes, pots:
 
 1. Configura `translate_copyright = true` a `config.toml`.
-2. Afegeix una clau `copyright` als arxius `i18n`. Consulta la [documentació](/ca/blog/faq-languages/#com-puc-personalitzar-o-sobreescriure-una-cadena-de-text-específica-al-meu-lloc-web).
+2. Afegeix una traducció a `copyright_translations` per a l'idioma esperat (que coincideix amb la variable `lang`) de la manera següent:
+
+```toml
+copyright_translations.es = "© $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+```
 
 ---
 

--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -556,7 +556,7 @@ El text es processarà en Markdown. Per exemple, la configuració d'adalt:
 
 {{ dual_theme_image(light_src="blog/mastering-tabi-settings/img/copyright_light.webp", dark_src="blog/mastering-tabi-settings/img/copyright_dark.webp" alt="Secció de drets d'autor", full_width=true) }}
 
-Si tens un lloc multilingüe i vols establir diferents notificacions de drets d'autor per a diferents idiomes,afegeix la traducció corresponent a `copyright_translations.{codi_d'idioma}` per a cada idioma que vulguis donar suport. El codi de llengua ha de coincidir amb el [codi de llengua de tabi](https://welpo.github.io/tabi/ca/blog/faq-languages/#que-son-aquests-codis-de-dues-lletres). Per exemple, pel castellà:
+Si tens un lloc multilingüe i vols establir diferents notificacions de drets d'autor per a diferents idiomes, afegeix la traducció corresponent a `copyright_translations.{codi_d'idioma}` per a cada idioma que vulguis donar suport. El codi de llengua ha de coincidir amb el [codi de llengua de tabi](https://welpo.github.io/tabi/ca/blog/faq-languages/#que-son-aquests-codis-de-dues-lletres). Per exemple, pel castellà:
 
 ```toml
 copyright_translations.es = "© $CURRENT_YEAR $AUTHOR $SEPARATOR A menos que se indique lo contrario, el contenido de esta web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."

--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -544,20 +544,22 @@ footer_menu = [
 Per afegir una menció sobre els drets d'autor al teu lloc web, configura `copyright`:
 
 ```toml
-copyright = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
+copyright = "© $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
 ```
 
-`$TITLE` es substituirà per el títol (variable `config.title`), `$CURRENT_YEAR` es substituirà per l'any actual i `$SEPARATOR` es substituirà per la [variable `separator`](#separador-personalitzat). El text es processarà en Markdown. Per exemple:
+- `$TITLE` serà reemplaçat per la variable `title` configurada a `config.toml`
+- `$CURRENT_YEAR` serà reemplaçat per l'any actual
+- `$AUTHOR` serà reemplaçat per la variable `author`
+- `$SEPARATOR` serà reemplaçat per la [variable `separator`](#separador-personalitzat).
+
+El text es processarà en Markdown. Per exemple, la configuració d'adalt:
 
 {{ dual_theme_image(light_src="blog/mastering-tabi-settings/img/copyright_light.webp", dark_src="blog/mastering-tabi-settings/img/copyright_dark.webp" alt="Secció de drets d'autor", full_width=true) }}
 
-Si tens un lloc multilingüe i vols establir diferents notificacions de drets d'autor per a diferents idiomes, pots:
-
-1. Configura `translate_copyright = true` a `config.toml`.
-2. Afegeix una traducció a `copyright_translations` per a l'idioma esperat (que coincideix amb la variable `lang`) de la manera següent:
+Si tens un lloc multilingüe i vols establir diferents notificacions de drets d'autor per a diferents idiomes,afegeix la traducció corresponent a `copyright_translations.{codi_d'idioma}` per a cada idioma que vulguis donar suport. El codi de llengua ha de coincidir amb el [codi de llengua de tabi](https://welpo.github.io/tabi/ca/blog/faq-languages/#que-son-aquests-codis-de-dues-lletres). Per exemple, pel castellà:
 
 ```toml
-copyright_translations.es = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+copyright_translations.es = "© $CURRENT_YEAR $AUTHOR $SEPARATOR A menos que se indique lo contrario, el contenido de esta web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
 ```
 
 ---

--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -544,10 +544,10 @@ footer_menu = [
 Per afegir una menció sobre els drets d'autor al teu lloc web, configura `copyright`:
 
 ```toml
-copyright = "© $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
+copyright = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
 ```
 
-`$CURRENT_YEAR` es substituirà per l'any actual i `$SEPARATOR` es substituirà per la [variable `separator`](#separador-personalitzat). El text es processarà en Markdown. Per exemple:
+`$TITLE` es substituirà per el títol (variable `config.title`), `$CURRENT_YEAR` es substituirà per l'any actual i `$SEPARATOR` es substituirà per la [variable `separator`](#separador-personalitzat). El text es processarà en Markdown. Per exemple:
 
 {{ dual_theme_image(light_src="blog/mastering-tabi-settings/img/copyright_light.webp", dark_src="blog/mastering-tabi-settings/img/copyright_dark.webp" alt="Secció de drets d'autor", full_width=true) }}
 
@@ -557,7 +557,7 @@ Si tens un lloc multilingüe i vols establir diferents notificacions de drets d'
 2. Afegeix una traducció a `copyright_translations` per a l'idioma esperat (que coincideix amb la variable `lang`) de la manera següent:
 
 ```toml
-copyright_translations.es = "© $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+copyright_translations.es = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
 ```
 
 ---

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -542,20 +542,22 @@ footer_menu = [
 Para añadir una mención sobre los derechos de autor a tu sitio web, configura `copyright`:
 
 ```toml
-copyright = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
+copyright = "© $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
 ```
 
-`$TITLE` se reemplazará por el título (variable `config.title`), `$CURRENT_YEAR` se reemplazará por el año actual y `$SEPARATOR` se reemplazará por la [variable `separator`](#separador-personalizado). Se procesará el texto en Markdown. Por ejemplo:
+- `$TITLE` será reemplazado por la variable `title` configurada en `config.toml`
+- `$CURRENT_YEAR` será reemplazado por el año actual
+- `$AUTHOR` será reemplazado por la variable `author`
+- `$SEPARATOR` será reemplazado por la [variable `separator`](#separador-personalizado).
+
+Se procesará el texto en Markdown. Por ejemplo, la configuració de arriba:
 
 {{ dual_theme_image(light_src="blog/mastering-tabi-settings/img/copyright_light.webp", dark_src="blog/mastering-tabi-settings/img/copyright_dark.webp" alt="Sección de derechos de autor", full_width=true) }}
 
-Si tienes un sitio multilingüe y deseas establecer diferentes notificaciones de derechos de autor para diferentes idiomas, puedes:
-
-1. Configura `translate_copyright = true` en `config.toml`.
-2. Añade una traducción en `copyright_translations` para el idioma esperado (que coincida con la variable `lang`) de la siguiente manera:
+Si tienes un sitio multilingüe y deseas establecer diferentes notificaciones de derechos de autor para diferentes idiomas, añade la traducción correspondiente a `copyright_translations.{código_de_idioma}` para cada idioma que quieras dar soporte. El código de idioma debe coincidir con el [código de idioma de tabi](https://welpo.github.io/tabi/es/blog/faq-languages/#que-son-estos-codigos-de-dos-letras). Por ejemplo:
 
 ```toml
-copyright_translations.es = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+copyright_translations.es = "© $CURRENT_YEAR $AUTHOR $SEPARATOR A menos que se indique lo contrario, el contenido de esta web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
 ```
 
 ---

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -552,7 +552,11 @@ copyright = "© $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the c
 Si tienes un sitio multilingüe y deseas establecer diferentes notificaciones de derechos de autor para diferentes idiomas, puedes:
 
 1. Configura `translate_copyright = true` en `config.toml`.
-2. Añade una clave `copyright` a los archivos `i18n`. Consulta la [documentación](/es/blog/faq-languages/#cómo-personalizo-o-sobrescribo-una-cadena-de-texto-específica-en-mi-sitio-web).
+2. Añade una traducción en `copyright_translations` para el idioma esperado (que coincida con la variable `lang`) de la siguiente manera:
+
+```toml
+copyright_translations.es = "© $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+```
 
 ---
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -542,10 +542,10 @@ footer_menu = [
 Para añadir una mención sobre los derechos de autor a tu sitio web, configura `copyright`:
 
 ```toml
-copyright = "© $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
+copyright = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
 ```
 
-`$CURRENT_YEAR` se reemplazará por el año actual y `$SEPARATOR` se reemplazará por la [variable `separator`](#separador-personalizado). Se procesará el texto en Markdown. Por ejemplo:
+`$TITLE` se reemplazará por el título (variable `config.title`), `$CURRENT_YEAR` se reemplazará por el año actual y `$SEPARATOR` se reemplazará por la [variable `separator`](#separador-personalizado). Se procesará el texto en Markdown. Por ejemplo:
 
 {{ dual_theme_image(light_src="blog/mastering-tabi-settings/img/copyright_light.webp", dark_src="blog/mastering-tabi-settings/img/copyright_dark.webp" alt="Sección de derechos de autor", full_width=true) }}
 
@@ -555,7 +555,7 @@ Si tienes un sitio multilingüe y deseas establecer diferentes notificaciones de
 2. Añade una traducción en `copyright_translations` para el idioma esperado (que coincida con la variable `lang`) de la siguiente manera:
 
 ```toml
-copyright_translations.es = "© $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+copyright_translations.es = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
 ```
 
 ---

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -556,7 +556,11 @@ copyright = "© $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the c
 If you have a multilingual site and want to set different copyright notices for different languages, you can:
 
 1. Set `translate_copyright = true` in `config.toml`.
-2. Add a `copyright` key to the `i18n` files. See the [documentation](/blog/faq-languages/#how-do-i-customise-or-override-a-specific-text-string-on-my-website).
+2. Add a translation to `copyright_translations` for the expected language (matching the `lang` variable) as follow:
+
+```toml
+copyright_translations.es = "© $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+```
 
 ---
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -546,20 +546,24 @@ footer_menu = [
 To add a copyright notice to your site, set `copyright`:
 
 ```toml
-copyright = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
+copyright = "© $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
 ```
 
-`$TITLE` will be replaced by the title (`config.title` variable), `$CURRENT_YEAR` will be replaced by the current year, and `$SEPARATOR` will be replaced by the [`separator` variable](#custom-separator). Markdown is rendered. The example above:
+You can use the following variables:
+
+- `$TITLE` will be replaced by `title` variable set in `config.toml`
+- `$CURRENT_YEAR` will be replaced by the current year
+- `$AUTHOR` will be replaced by the `author` variable
+- `$SEPARATOR` will be replaced by the [`separator` variable](#custom-separator)
+
+Markdown is rendered. The example above:
 
 {{ dual_theme_image(light_src="blog/mastering-tabi-settings/img/copyright_light.webp", dark_src="blog/mastering-tabi-settings/img/copyright_dark.webp" alt="Copyright section", full_width=true) }}
 
-If you have a multilingual site and want to set different copyright notices for different languages, you can:
-
-1. Set `translate_copyright = true` in `config.toml`.
-2. Add a translation to `copyright_translations` for the expected language (matching the `lang` variable) as follow:
+If you have a multilingual site and want to set different copyright notices for different languages, you can add the corresponding translation to `copyright_translations.{language_code}` for each language you want to support. The language code must match [tabi's language code](https://welpo.github.io/tabi/blog/faq-languages/#what-are-these-two-letter-codes). For example, for Spanish:
 
 ```toml
-copyright_translations.es = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+copyright_translations.es = "© $CURRENT_YEAR $AUTHOR $SEPARATOR A menos que se indique lo contrario, el contenido de esta web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
 ```
 
 ---

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -546,10 +546,10 @@ footer_menu = [
 To add a copyright notice to your site, set `copyright`:
 
 ```toml
-copyright = "© $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
+copyright = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
 ```
 
-`$CURRENT_YEAR` will be replaced by the current year, and `$SEPARATOR` will be replaced by the [`separator` variable](#custom-separator). Markdown is rendered. The example above:
+`$TITLE` will be replaced by the title (`config.title` variable), `$CURRENT_YEAR` will be replaced by the current year, and `$SEPARATOR` will be replaced by the [`separator` variable](#custom-separator). Markdown is rendered. The example above:
 
 {{ dual_theme_image(light_src="blog/mastering-tabi-settings/img/copyright_light.webp", dark_src="blog/mastering-tabi-settings/img/copyright_dark.webp" alt="Copyright section", full_width=true) }}
 
@@ -559,7 +559,7 @@ If you have a multilingual site and want to set different copyright notices for 
 2. Add a translation to `copyright_translations` for the expected language (matching the `lang` variable) as follow:
 
 ```toml
-copyright_translations.es = "© $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+copyright_translations.es = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
 ```
 
 ---

--- a/templates/partials/copyright.html
+++ b/templates/partials/copyright.html
@@ -1,0 +1,41 @@
+{%- if config.extra.copyright -%}
+    {% set copyright = config.extra.copyright %}
+    {# Try to look for a language-specific copyright notice in the new config setup #}
+    {%- if config.extra.copyright_translations -%}
+        {%- if lang in config.extra.copyright_translations -%}
+            {% set copyright = config.extra.copyright_translations[lang] %}
+        {%- endif -%}
+    {%- elif config.extra.translate_copyright -%}
+        {# Old way to translate the copyright through toml files #}
+        {# When the feature is removed, uncomment below to throw a descriptive error #}
+        {# {{ throw(message="ERROR: The 'translate_copyright' feature has been deprecated. Please set 'copyright_translations' in config.toml. See the documentation: https://welpo.github.io/tabi/blog/mastering-tabi-settings/#copyright") }} #}
+        {% set copyright = macros_translate::translate(key="copyright", default=config.extra.copyright, language_strings=language_strings) %}
+    {%- endif -%}
+
+    {# Check for missing variables in the notice #}
+    {% set copyright_placeholders = ["$AUTHOR", "$TITLE"] %}
+    {% set missing_vars = [] %}
+    {% for placeholder in copyright_placeholders %}
+        {% if placeholder in copyright %}
+            {# Attempt to retrieve the corresponding variable by trimming the $ sign and converting to lowercase #}
+            {% set var_name = placeholder | replace(from="$", to="") | lower %}
+            {% if not config[var_name] %}
+                {# Append the variable name to the list of missing variables #}
+                {% set_global missing_vars = missing_vars | concat(with=var_name) %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+
+    {% if missing_vars | length > 0 %}
+        {% set missing_vars_str = missing_vars | join(sep=", ") %}
+        {{ throw(message="ERROR: The following variables are included in `copyright` but have not been set in the config.toml: " ~ missing_vars_str) }}
+    {% endif %}
+
+    {# At this point, we know that all variables needed defined, so we can safely override the missing ones #}
+    {% set author = config.author | default(value="") %}
+    {% set title = config.title | default(value="") %}
+
+    {# Render the copyright notice, replacing the variables #}
+    {% set current_year = now() | date(format="%Y") %}
+    <p>{{ copyright | replace(from="$AUTHOR", to=author) | replace(from="$TITLE", to=title) | replace(from="$CURRENT_YEAR", to=current_year) | replace(from="$SEPARATOR", to=separator) | markdown | safe }}</p>
+{%- endif -%}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -90,13 +90,21 @@
                 {%- if config.extra.copyright -%}
                     {% set current_year = now() | date(format="%Y") %}
                     {% set copyright = config.extra.copyright %}
-                    {# Translate the copyright if set in the config #}
-                    {%- if config.extra.translate_copyright -%}
+
+                    {# Try to look for a language-specific copyright notice in the new config setup #}
+                    {%- if config.extra.copyright_translations -%}
                         {%- if lang in config.extra.copyright_translations -%}
                             {% set copyright = config.extra.copyright_translations[lang] %}
                         {%- endif -%}
+                    {%- elif config.extra.translate_copyright -%}
+                        {# Old way to translate the copyright through toml files #}
+                        {# When the feature is removed, uncomment below to throw a descriptive error #}
+                        {# {{ throw(message="ERROR: The 'translate_copyright' feature has been deprecated. Please use 'copyright_translations' in the config.toml. See the documentation: https://welpo.github.io/tabi/blog/mastering-tabi-settings/#copyright") }} #}
+                        {% set copyright = macros_translate::translate(key="copyright", default=config.extra.copyright, language_strings=language_strings) %}
                     {%- endif -%}
-                    <p>{{ copyright | replace(from="$TITLE", to=config.title) | replace(from="$CURRENT_YEAR", to=current_year) | replace(from="$SEPARATOR", to=separator) | markdown | safe }}</p>
+
+                    {# Render the copyright notice, replacing the variables #}
+                    <p>{{ copyright | replace(from="$AUTHOR", to=config.author) | replace(from="$TITLE", to=config.title) | replace(from="$CURRENT_YEAR", to=current_year) | replace(from="$SEPARATOR", to=separator) | markdown | safe }}</p>
                 {%- endif -%}
 
                 {# Shows "Powered by Zola & tabi" notice #}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -86,28 +86,7 @@
 
         <div class="credits">
             <small>
-                {# Shows optional Copyright notice #}
-                {%- if config.extra.copyright -%}
-                    {% set author = config.author | default(value="") %}
-                    {% set title = config.title | default(value="") %}
-                    {% set current_year = now() | date(format="%Y") %}
-                    {% set copyright = config.extra.copyright %}
-
-                    {# Try to look for a language-specific copyright notice in the new config setup #}
-                    {%- if config.extra.copyright_translations -%}
-                        {%- if lang in config.extra.copyright_translations -%}
-                            {% set copyright = config.extra.copyright_translations[lang] %}
-                        {%- endif -%}
-                    {%- elif config.extra.translate_copyright -%}
-                        {# Old way to translate the copyright through toml files #}
-                        {# When the feature is removed, uncomment below to throw a descriptive error #}
-                        {# {{ throw(message="ERROR: The 'translate_copyright' feature has been deprecated. Please use 'copyright_translations' in the config.toml. See the documentation: https://welpo.github.io/tabi/blog/mastering-tabi-settings/#copyright") }} #}
-                        {% set copyright = macros_translate::translate(key="copyright", default=config.extra.copyright, language_strings=language_strings) %}
-                    {%- endif -%}
-
-                    {# Render the copyright notice, replacing the variables #}
-                    <p>{{ copyright | replace(from="$AUTHOR", to=author) | replace(from="$TITLE", to=title) | replace(from="$CURRENT_YEAR", to=current_year) | replace(from="$SEPARATOR", to=separator) | markdown | safe }}</p>
-                {%- endif -%}
+                {% include "partials/copyright.html" %}
 
                 {# Shows "Powered by Zola & tabi" notice #}
                 {{ macros_translate::translate(key="powered_by", default="Powered by", language_strings=language_strings) }}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -96,7 +96,7 @@
                             {% set copyright = config.extra.copyright_translations[lang] %}
                         {%- endif -%}
                     {%- endif -%}
-                    <p>{{ copyright | replace(from="$CURRENT_YEAR", to=current_year) | replace(from="$SEPARATOR", to=separator) | markdown | safe }}</p>
+                    <p>{{ copyright | replace(from="$TITLE", to=config.title) | replace(from="$CURRENT_YEAR", to=current_year) | replace(from="$SEPARATOR", to=separator) | markdown | safe }}</p>
                 {%- endif -%}
 
                 {# Shows "Powered by Zola & tabi" notice #}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -89,12 +89,14 @@
                 {# Shows optional Copyright notice #}
                 {%- if config.extra.copyright -%}
                     {% set current_year = now() | date(format="%Y") %}
+                    {% set copyright = config.extra.copyright %}
                     {# Translate the copyright if set in the config #}
                     {%- if config.extra.translate_copyright -%}
-                        <p>{{ macros_translate::translate(key="copyright", default=config.extra.copyright, language_strings=language_strings) | replace(from="$CURRENT_YEAR", to=current_year) | replace(from="$SEPARATOR", to=separator) | markdown | safe }}</p>
-                    {%- else -%}
-                        <p>{{ config.extra.copyright | replace(from="$CURRENT_YEAR", to=current_year) | replace(from="$SEPARATOR", to=separator) | markdown | safe }}</p>
+                        {%- if lang in config.extra.copyright_translations -%}
+                            {% set copyright = config.extra.copyright_translations[lang] %}
+                        {%- endif -%}
                     {%- endif -%}
+                    <p>{{ copyright | replace(from="$CURRENT_YEAR", to=current_year) | replace(from="$SEPARATOR", to=separator) | markdown | safe }}</p>
                 {%- endif -%}
 
                 {# Shows "Powered by Zola & tabi" notice #}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -88,6 +88,8 @@
             <small>
                 {# Shows optional Copyright notice #}
                 {%- if config.extra.copyright -%}
+                    {% set author = config.author | default(value="") %}
+                    {% set title = config.title | default(value="") %}
                     {% set current_year = now() | date(format="%Y") %}
                     {% set copyright = config.extra.copyright %}
 
@@ -104,7 +106,7 @@
                     {%- endif -%}
 
                     {# Render the copyright notice, replacing the variables #}
-                    <p>{{ copyright | replace(from="$AUTHOR", to=config.author) | replace(from="$TITLE", to=config.title) | replace(from="$CURRENT_YEAR", to=current_year) | replace(from="$SEPARATOR", to=separator) | markdown | safe }}</p>
+                    <p>{{ copyright | replace(from="$AUTHOR", to=author) | replace(from="$TITLE", to=title) | replace(from="$CURRENT_YEAR", to=current_year) | replace(from="$SEPARATOR", to=separator) | markdown | safe }}</p>
                 {%- endif -%}
 
                 {# Shows "Powered by Zola & tabi" notice #}

--- a/theme.toml
+++ b/theme.toml
@@ -173,8 +173,12 @@ encode_plaintext_email = true  # Setting is ignored if email is already encoded.
 # copyright = "© $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
 
 # For multi-language sites, you can set a different copyright for each language.
-# If this is set to true, ensure you have a `copyright` translation for each language.
+# If this is set to true, ensure you have a translation in `copyright_translations` for each language.
 translate_copyright = false
+# If `translate_copyright` is set to true, `copyright_translations` can be empty but must exist.
+# A build time error will be raised otherwise in order to make sure people already using previous translation method (i18n files) won't forgot to move translations back in config.toml.
+# If a translation is missing for language, the `copyright` value will be used instead.
+# copyright_translations.es = "© $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
 
 # Custom security headers. What urls should your website be able to connect to?
 # You need to specify the CSP and the URLs associated with the directive.

--- a/theme.toml
+++ b/theme.toml
@@ -167,10 +167,11 @@ encode_plaintext_email = true  # Setting is ignored if email is already encoded.
 # ]
 
 # Enable a copyright notice for the footer, shown between socials and the "Powered by" text.
+# $TITLE will be replaced by the website's title.
 # You can use $CURRENT_YEAR to automatically insert the current year.
 # $SEPARATOR will be replaced by the `separator` variable.
 # Markdown is supported (links, emphasis, etc).
-# copyright = "© $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
+# copyright = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
 
 # For multi-language sites, you can set a different copyright for each language.
 # If this is set to true, ensure you have a translation in `copyright_translations` for each language.
@@ -178,7 +179,7 @@ translate_copyright = false
 # If `translate_copyright` is set to true, `copyright_translations` can be empty but must exist.
 # A build time error will be raised otherwise in order to make sure people already using previous translation method (i18n files) won't forgot to move translations back in config.toml.
 # If a translation is missing for language, the `copyright` value will be used instead.
-# copyright_translations.es = "© $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+# copyright_translations.es = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
 
 # Custom security headers. What urls should your website be able to connect to?
 # You need to specify the CSP and the URLs associated with the directive.

--- a/theme.toml
+++ b/theme.toml
@@ -177,7 +177,7 @@ encode_plaintext_email = true  # Setting is ignored if email is already encoded.
 # For multi-language sites, you can set a different copyright for each language.
 # The old way of setting `translated_copyright = true` and using i18n files is deprecated.
 # If a translation is missing for language, the `copyright` value will be used.
-# copyright_translations.es = "$TITLE © $CURRENT_YEAR Tu Nombre $SEPARATOR A menos que se indique lo contrario, el contenido de esta web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+# copyright_translations.es = "$TITLE © $CURRENT_YEAR $AUTHOR $SEPARATOR A menos que se indique lo contrario, el contenido de esta web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
 
 # Custom security headers. What urls should your website be able to connect to?
 # You need to specify the CSP and the URLs associated with the directive.

--- a/theme.toml
+++ b/theme.toml
@@ -168,18 +168,16 @@ encode_plaintext_email = true  # Setting is ignored if email is already encoded.
 
 # Enable a copyright notice for the footer, shown between socials and the "Powered by" text.
 # $TITLE will be replaced by the website's title.
-# You can use $CURRENT_YEAR to automatically insert the current year.
+# $CURRENT_YEAR will be replaced by the current year.
+# $AUTHOR will be replaced by the `author` variable.
 # $SEPARATOR will be replaced by the `separator` variable.
 # Markdown is supported (links, emphasis, etc).
-# copyright = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
+# copyright = "$TITLE © $CURRENT_YEAR $AUTHOR $SEPARATOR Unless otherwise noted, the content in this website is available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license."
 
 # For multi-language sites, you can set a different copyright for each language.
-# If this is set to true, ensure you have a translation in `copyright_translations` for each language.
-translate_copyright = false
-# If `translate_copyright` is set to true, `copyright_translations` can be empty but must exist.
-# A build time error will be raised otherwise in order to make sure people already using previous translation method (i18n files) won't forgot to move translations back in config.toml.
-# If a translation is missing for language, the `copyright` value will be used instead.
-# copyright_translations.es = "$TITLE © $CURRENT_YEAR Your Name $SEPARATOR A menos que se indique lo contrario, el contenido de este sitio web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
+# The old way of setting `translated_copyright = true` and using i18n files is deprecated.
+# If a translation is missing for language, the `copyright` value will be used.
+# copyright_translations.es = "$TITLE © $CURRENT_YEAR Tu Nombre $SEPARATOR A menos que se indique lo contrario, el contenido de esta web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
 
 # Custom security headers. What urls should your website be able to connect to?
 # You need to specify the CSP and the URLs associated with the directive.


### PR DESCRIPTION
As copyright is part of config, it is easier to manage its translations at the same place.
`config.extra.translate_copyright` is still used to declare translation intent for backward compatibility.
It allows to raise an error at build time if someone forgot to move from using i18n files as previously required to the config.toml.

In addition, `$TITLE` is now replaced by the website's title in the copyright.