### PR TITLE
✨ feat(comments): allow page override of global system

### DIFF
--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuració de tabi: guia completa"
 date = 2023-09-18
-updated = 2023-10-05
+updated = 2023-10-27
 description = "Descobreix les múltiples maneres en què pots personalitzar tabi."
 
 [taxonomies]
@@ -453,6 +453,8 @@ Per defecte, el feed Atom només conté el resum o descripció de les teves publ
 Per activar els comentaris en una pàgina, establert el nom del sistema com a `true` al front matter. Per exemple, `utterances = true`.
 
 Si vols activar els comentaris de forma global, pots fer-ho establint `enabled_for_all_posts = true` a la secció apropiada del teu `config.toml` (per exemple, a `[extra.giscus]`).
+
+Si has activat un sistema de forma global i vols desactivar-lo per a una pàgina específica, pots fer-ho establint el nom del sistema com a `false` al front matter. Per exemple, `utterances = false`.
 
 Llegeix la [documentació](/ca/blog/comments/) per a més informació sobre els sistemes disponibles i la seva configuració.
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuración de tabi: guía completa"
 date = 2023-09-18
-updated = 2023-10-05
+updated = 2023-10-27
 description = "Descubre las múltiples maneras en que puedes personalizar tabi."
 
 [taxonomies]
@@ -451,6 +451,8 @@ Por defecto, el feed Atom solo contiene el resumen/descripción de tus publicaci
 Para activar los comentarios en una página, establece el nombre del sistema como `true` en el front matter. Por ejemplo, `utterances = true`.
 
 Si quieres activar los comentarios de forma global, puedes hacerlo estableciendo `enabled_for_all_posts = true` en la sección apropiada de tu `config.toml` (por ejemplo, en `[extra.giscus]`).
+
+Si has activado un sistema globalmente, pero quieres desactivarlo en una página específica, puedes hacerlo estableciendo el nombre del sistema como `false` en el front matter. Por ejemplo, `utterances = false`.
 
 Lee la [documentación](/es/blog/comments/) para obtener más información sobre los sistemas disponibles y su configuración.
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Mastering tabi Settings: A Comprehensive Guide"
 date = 2023-09-18
-updated = 2023-10-05
+updated = 2023-10-27
 description = "Discover the many ways you can customise your tabi site."
 
 [taxonomies]
@@ -455,6 +455,8 @@ By default, the Atom feed only contains the summary/description of your posts. Y
 To enable comments on an individual page, set the name of the system you want to enable to `true` in the front matter. For example, `utterances = true`.
 
 To enable a system globally (on all pages), set `enabled_for_all_posts = true` in the correct section of your `config.toml` (e.g. inside `[extra.giscus]`).
+
+If you have enabled a system globally, but want to disable it on a specific page, set the name of the system to `false` in the front matter of that page. For example, `utterances = false`.
 
 Read [the docs](/blog/comments/) for more information on the available systems and their setup.
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -46,6 +46,7 @@
         {% endfor %}
     </tbody>
 </table> #}
+{# {{ __tera_context }} #}
 {# End debugging #}
 
 <main>
@@ -107,33 +108,21 @@
             {{ page.content | replace(from="<!-- toc -->", to=macros_toc::toc(page=page, header=false, language_strings=language_strings)) | safe }}
         </section>
 
-        {# Check if comments are enabled #}
-        {% set giscus_enabled = config.extra.giscus.enabled_for_all_posts or page.extra.giscus %}
-        {% set utterances_enabled = config.extra.utterances.enabled_for_all_posts or page.extra.utterances %}
-        {% set hyvortalk_enabled = config.extra.hyvortalk.enabled_for_all_posts or page.extra.hyvortalk %}
-        {% set isso_enabled = config.extra.isso.enabled_for_all_posts or page.extra.isso %}
-
-        {# Ensure only one comment system is enabled #}
-        {# Counter for enabled comment systems #}
+        {# Check if comments are enabled, checking that they are not disabled on the specific page #}
+        {% set systems = ["giscus", "utterances", "hyvortalk", "isso"] %}
         {% set enabled_systems = 0 %}
+        {% set comment_system = "" %}
 
-        {# Check and count the enabled comment systems #}
-        {% if giscus_enabled %}
-            {% set comment_system = "giscus" %}
-            {% set enabled_systems = enabled_systems + 1 %}
-        {% endif %}
-        {% if utterances_enabled %}
-            {% set comment_system = "utterances" %}
-            {% set enabled_systems = enabled_systems + 1 %}
-        {% endif %}
-        {% if hyvortalk_enabled %}
-            {% set comment_system = "hyvortalk" %}
-            {% set enabled_systems = enabled_systems + 1 %}
-        {% endif %}
-        {% if isso_enabled %}
-            {% set comment_system = "isso" %}
-            {% set enabled_systems = enabled_systems + 1 %}
-        {% endif %}
+        {% for system in systems %}
+            {% set global_enabled = config.extra[system].enabled_for_all_posts | default(value=false) %}
+            {% set page_enabled = page.extra[system] | default(value=global_enabled) %}
+            {% set is_enabled = global_enabled and page_enabled != false or page_enabled == true %}
+
+            {% if is_enabled %}
+                {% set_global comment_system = system %}
+                {% set_global enabled_systems = enabled_systems + 1 %}
+            {% endif %}
+        {% endfor %}
 
         {# Ensure only one comment system is enabled #}
         {% if enabled_systems > 1 %}


### PR DESCRIPTION
## Summary
This pull request adds the ability to override global settings for comment systems at the page-level. Additionally, it refactors the existing code to make it more concise and maintainable.

## Changes

- **Page-specific overrides**: Adds the capability to disable comment systems on individual pages, overriding global settings. Useful for non-articles like "about", "privacy policy", etc. For example, if you have isso enabled globally, you can disable it for a specific page with `isso = false`.
  
- **Code refactoring**: Simplifies the existing logic by using loops and making the code more DRY (Don't Repeat Yourself).

- **Documentation**: This feature is documented in the [Mastering tabi](https://welpo.github.io/tabi/blog/mastering-tabi-settings/) post.

### Technical details
The Tera template code for enabling comment systems has been refactored to iterate over an array of systems. This makes it easier to manage and extend.