### PR TITLE
📈 chore(demo-site): add analytics and privacy policy

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -183,9 +183,9 @@ socials = [
 # Extra menu to show on the footer, below socials section.
 footer_menu = [
     {url = "about", name = "about", trailing_slash = true},
-    # {url = "privacy", name = "privacy", trailing_slash = true},
+    {url = "privacy", name = "privacy", trailing_slash = true},
+    {url = "https://tabi-stats.osc.garden", name = "site_statistics", trailing_slash = true},
     {url = "sitemap.xml", name = "sitemap", trailing_slash = false},
-    # {url = "https://example.com", name = "external link", trailing_slash = true},
 ]
 
 # Enable a copyright notice for the footer, shown between socials and the "Powered by" text.
@@ -221,7 +221,7 @@ custom_subset = true
 [extra.analytics]
 # Specify which analytics service you want to use.
 # Supported options: ["goatcounter", "umami", "plausible"]
-# service = "umami"
+service = "goatcounter"
 
 # Unique identifier for tracking.
 # For GoatCounter, this is the code you choose during signup.
@@ -235,7 +235,7 @@ custom_subset = true
 # For Umami: Base URL like "https://umami.example.com"
 # For Plausible: Base URL like "https://plausible.example.com"
 # Leave this field empty if you're using the service's default hosting.
-# self_hosted_url = ""
+self_hosted_url = "https://tabi-stats.osc.garden"
 
 # giscus support for comments. https://giscus.app
 # Setup instructions: https://welpo.github.io/tabi/blog/comments/#setup

--- a/content/pages/privacy/index.ca.md
+++ b/content/pages/privacy/index.ca.md
@@ -1,0 +1,96 @@
++++
+title = "Política de privacitat"
+path = "/ca/privacy"
+date = 2023-10-31
++++
+
+Aquesta política de privacitat detalla com recollim i processem les teves dades en aquest lloc web.
+
+{{ toc() }}
+
+## Quines dades recollim?
+
+### Navegació general {#what-general}
+
+Mentre navegues pel lloc, no es recull cap informació personal.
+
+### Comentaris {#what-comments}
+
+No recollim cap dada quan envieu un comentari o reacció, però GitHub sí que ho fa per proporcionar el servei.
+
+### Anàlisis {#what-analytics}
+
+Per a la millora del lloc web, es recullen les dades no personals següents:
+
+- **Referent**: la font que t'ha portat a aquest lloc.
+- **URL sol·licitat**: la pàgina específica que visites.
+- **Agent d'usuari**: identifica el navegador i el sistema operatiu que utilitzes (per exemple, "Safari 17.0, Mac OS X").
+- **Nom del país**: el país des d'on estàs visitant, determinat per la teva adreça IP.
+- **Idioma**: l'idioma configurat al teu navegador.
+- **Mida de pantalla**: les dimensions de la pantalla del teu dispositiu.
+- **Data i hora**: quan accedeixes al lloc.
+
+No seguim els visitants únics, i tampoc seguim quant de temps us quedeu al lloc ni on aneu en marxar.
+
+## Com recollim aquestes dades?
+
+### Comentaris {#how-comments}
+
+Les dades associades als comentaris es recullen utilitzant [giscus](https://giscus.app/), una plataforma que permet comentaris basada en GitHub.
+
+### Anàlisis {#how-analytics}
+
+Les dades no personals es recullen utilitzant una instància autoallotjada de [GoatCounter](https://www.goatcounter.com/), una plataforma d'anàlisis web de codi obert i respectuosa amb la privacitat.
+
+## Com utilitzarem les dades?
+
+Les dades enviades a GitHub s'utilitzen per mostrar el teu comentari al lloc.
+
+Les dades no personals s'utilitzen per generar estadístiques sobre el lloc, com el nombre de visitants per dia, o les pàgines i referents més populars. Aquestes dades s'utilitzen per millorar aquest lloc de demostració i el tema tabi. Pots veure les estadístiques generades a partir d'aquestes dades a la [pàgina d'estadístiques públiques](https://tabi-stats.osc.garden/).
+
+Totes les dades recollides estan públicament disponibles, ja sigui en forma de comentaris o estadístiques.
+
+No utilitzem les dades per cap altre propòsit.
+
+## Com emmagatzemem les dades?
+
+Les dades dels comentaris no s'emmagatzemen per Giscus, tal com s'especifica a la seva [política de privacitat](https://github.com/giscus/giscus/blob/main/PRIVACY-POLICY.md#what-data-do-we-collect). Les dades s'emmagatzemen als servidors de GitHub. Vegeu la [política de privacitat de GitHub](https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement).
+
+Les dades d'anàlisis s'emmagatzemen en un servidor allotjat per [Oracle Cloud](https://cloud.oracle.com/). El servidor es troba a Àmsterdam, Països Baixos.
+
+El servidor segueix les millors pràctiques de la indústria per a la seguretat, incloent actualitzacions de seguretat automàtiques, una política de seguretat de contingut estricta, un tallafocs, accés SSH basat en claus, etc.
+
+## Quant de temps emmagatzemarem les dades?
+
+Els comentaris s'emmagatzemen indefinidament, o fins que sol·licitis la seva eliminació.
+
+La resta de dades s'emmagatzemen indefinidament.
+
+## Quins són els teves drets de protecció de dades?
+
+Depenent del processament i de la base legal, hi ha diverses possibilitats disponibles per a que mantinguis el control sobre les teves dades personals:
+
+- Dret d'accés a les teves dades
+- Dret de modificar les teves dades
+- Dret d'oposar-se al processament de les teves dades personals
+- Dret de limitar el processament de les teves dades
+- Dret de supressió de les teves dades
+- Dret de retirar el teu consentiment
+
+Si fas una sol·licitud, tenim un mes per respondre't. Si vols exercir algun d'aquests drets, si us plau, posa't en contacte amb nosaltres utilitzant la icona de correu electrònic al peu de pàgina del lloc.
+
+## Galetes (cookies)
+
+El lloc no utilitza galetes.
+
+## Polítiques de privacitat d'altres llocs web
+
+Aquest lloc web conté enllaços a altres llocs web. Aquesta política de privacitat només s'aplica a aquest lloc web, així que si cliques en un enllaç cap a un altre lloc web, hauries de llegir la seva política de privacitat.
+
+## Canvis a la política de privacitat
+
+Mantindrem aquesta política de privacitat sota revisió regular i col·locarem qualsevol actualització en aquesta pàgina web. Aquesta política de privacitat es va actualitzar per última vegada el 2023-10-31.
+
+## Com posar-te en contacte amb nosaltres
+
+Si tens alguna pregunta sobre aquesta política de privacitat, les dades que tenim sobre tu, o vols exercir algun dels teus drets de protecció de dades, si us plau, no dubtis a posar-te en contacte amb nosaltres utilitzant la icona de correu electrònic al peu de pàgina del lloc.

--- a/content/pages/privacy/index.es.md
+++ b/content/pages/privacy/index.es.md
@@ -1,0 +1,96 @@
++++
+title = "Política de privacidad"
+path = "/es/privacy"
+date = 2023-10-31
++++
+
+Esta política de privacidad describe cómo recopilamos y procesamos tus datos en este sitio web.
+
+{{ toc() }}
+
+## ¿Qué datos recopilamos?
+
+### Navegación general {#what-general}
+
+Mientras navegas por el sitio, no se recopila ninguna información personal.
+
+### Comentarios {#what-comments}
+
+No recopilamos ningún dato cuando envías un comentario o reacción, pero GitHub sí lo hace para proporcionar el servicio.
+
+### Análisis {#what-analytics}
+
+Para mejorar el sitio web, se recopila la siguiente información no personal:
+
+- **Referente**: la fuente que te llevó a este sitio.
+- **URL solicitado**: la página específica que visitas.
+- **Agente de usuario**: identifica el navegador y el sistema operativo que utilizas (por ejemplo, "Safari 17.0, Mac OS X").
+- **Nombre del país**: el país desde el que estás visitando, determinado por tu dirección IP.
+- **Idioma**: el idioma configurado en tu navegador.
+- **Tamaño de pantalla**: las dimensiones de la pantalla de tu dispositivo.
+- **Fecha y hora**: cuándo accedes al sitio.
+
+No rastreamos visitantes únicos ni el tiempo que permaneces en el sitio o a dónde vas después de salir.
+
+## ¿Cómo recopilamos estos datos?
+
+### Comentarios {#how-comments}
+
+Los datos asociados con los comentarios se recopilan utilizando [giscus](https://giscus.app/), una plataforma que habilita comentarios basados en GitHub.
+
+### Análisis {#how-analytics}
+
+Los datos no personales se recopilan mediante una instancia autoalojada de [GoatCounter](https://www.goatcounter.com/), una plataforma de análisis web de código abierto y respetuosa con la privacidad.
+
+## ¿Cómo utilizaremos los datos?
+
+Los datos enviados a GitHub se utilizan para mostrar tu comentario en el sitio.
+
+Los datos no personales se utilizan para generar estadísticas sobre el sitio, como el número de visitantes por día o las páginas y referentes más populares. Estos datos se utilizan para mejorar este sitio de demostración y el tema tabi. Puedes ver las estadísticas generadas a partir de estos datos en la [página de estadísticas públicas](https://tabi-stats.osc.garden/).
+
+Todos los datos recopilados están públicamente disponibles, ya sea en forma de comentarios o estadísticas.
+
+No utilizamos los datos para ningún otro propósito.
+
+## ¿Cómo almacenamos los datos?
+
+Los datos de los comentarios no son almacenados por Giscus, como se especifica en su [política de privacidad](https://github.com/giscus/giscus/blob/main/PRIVACY-POLICY.md#what-data-do-we-collect). Los datos se almacenan en servidores de GitHub. Consulta la [política de privacidad de GitHub](https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement).
+
+Los datos de análisis se almacenan en un servidor alojado por [Oracle Cloud](https://cloud.oracle.com/). El servidor está ubicado en Amsterdam, Países Bajos.
+
+El servidor sigue las mejores prácticas de la industria en cuanto a seguridad, incluidas actualizaciones de seguridad automáticas, una estricta Política de Seguridad de Contenido, un cortafuegos, acceso SSH basado en clave, etc.
+
+## ¿Cuánto tiempo almacenaremos los datos?
+
+Los comentarios se almacenan indefinidamente o hasta que solicites su eliminación.
+
+El resto de los datos se almacena indefinidamente.
+
+## ¿Cuáles son tus derechos de protección de datos?
+
+Dependiendo del procesamiento y la base legal, dispones de varias opciones para mantener el control sobre tus datos personales:
+
+- Derecho a acceder a tus datos
+- Derecho a enmendar tus datos
+- Derecho a oponerte al procesamiento de tus datos personales
+- Derecho a limitar el procesamiento de tus datos
+- Derecho a que se eliminen tus datos
+- Derecho a retirar tu consentimiento
+
+Si realizas una solicitud, tenemos un mes para responderte. Si deseas ejercer alguno de estos derechos, contáctanos utilizando el icono de correo electrónico en el pie de página del sitio.
+
+## Cookies
+
+El sitio no utiliza cookies.
+
+## Políticas de privacidad de otros sitios web
+
+Este sitio web contiene enlaces a otros sitios web. Esta política de privacidad sólo se aplica a este sitio web, por lo que si haces clic en un enlace a otro sitio web, debes leer su política de privacidad.
+
+## Cambios en la política de privacidad
+
+Mantenemos esta política de privacidad bajo revisión regular y colocamos cualquier actualización en esta página web. Esta política de privacidad se actualizó por última vez el 2023-10-31.
+
+## Cómo contactarnos
+
+Si tienes alguna pregunta sobre esta política de privacidad, los datos que tenemos sobre ti o si te gustaría ejercer alguno de tus derechos de protección de datos, no dudes en contactarnos utilizando el icono de correo electrónico en el pie de página del sitio.

--- a/content/pages/privacy/index.md
+++ b/content/pages/privacy/index.md
@@ -1,0 +1,96 @@
++++
+title = "Privacy Policy"
+path = "privacy"
+date = 2023-10-31
++++
+
+This privacy policy outlines how we collect and process your data on this website.
+
+{{ toc() }}
+
+## What data do we collect?
+
+### General browsing {#what-general}
+
+While browsing the site, no personal information is collected.
+
+### Comments {#what-comments}
+
+We do not collect any data when you send a comment or reaction, but GitHub does in order to provide the service.
+
+### Analytics {#what-analytics}
+
+For website improvement, the following non-personal data is collected:
+
+- **Referrer**: the source that led you to this site.
+- **Requested URL**: the specific page you visited.
+- **User-Agent**: identifies the browser and operating system you use (e.g. "Safari 17.0, Mac OS X").
+- **Country name**: the country you are visiting from, determined by your IP address.
+- **Language**: the language your browser is set to.
+- **Screen size**: the dimensions of your device's screen.
+- **Time**: when you accessed the site.
+
+We do not track unique visitors, and we do not track how long you stay on the site or where you go after you leave.
+
+## How do we collect this data?
+
+### Comments {#how-comments}
+
+The data associated with comments is collected using [giscus](https://giscus.app/), a platform that enables GitHub-based comments.
+
+### Analytics {#how-analytics}
+
+The non-personal data is collected using a self-hosted instance of [GoatCounter](https://www.goatcounter.com/), an open-source privacy-friendly web analytics platform.
+
+## How will we use the data?
+
+The data sent to GitHub is used to display your comment on the site.
+
+The non personal data is used to generate statistics about the site, such as the number of visitors per day, or the most popular pages and referrers. This data is used to improve this demo site and the tabi theme. You can see the statistics generated from this data on the [public stats page](https://tabi-stats.osc.garden/).
+
+All data collected is publically available, either in the form of comments or statistics.
+
+We do not use the data for any other purpose.
+
+## How do we store the data?
+
+The comments data is not stored by Giscus, as specified in their [privacy policy](https://github.com/giscus/giscus/blob/main/PRIVACY-POLICY.md#what-data-do-we-collect). The data is stored on GitHub servers. See the [GitHub's privacy policy](https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement).
+
+The analytics data is stored on a server hosted by [Oracle Cloud](https://cloud.oracle.com/). The server is located in Amsterdam, The Netherlands.
+
+The server follows industry best practices for security, including automatic security updates, a strict Content Security Policy, a firewall, key-based SSH access, etc.
+
+## How long will we store the data?
+
+The comments are stored indefinitely, or until you request their deletion.
+
+The rest of the data is stored indefinitely.
+
+## What are your data protection rights?
+
+Depending on the processing and the legal basis, there are a number of possibilities available to you to keep control over your personal data:
+
+- Right to access your data
+- Right to amend your data
+- Right to object to the processing of your personal data
+- Right to limit the processing of your data
+- Right to have your data deleted
+- Right to withdraw your consent
+
+If you make a request, we have one month to respond to you. If you would like to exercise any of these rights, please contact us using the e-mail icon in the footer of the site.
+
+## Cookies
+
+The site does not use cookies.
+
+## Privacy policies of other websites
+
+This website contains links to other websites. This privacy policy applies only to this website, so if you click on a link to another website, you should read their privacy policy.
+
+## Changes to the privacy policy
+
+We keep this privacy policy under regular review and place any updates on this web page. This privacy policy was last updated on 2023-10-31.
+
+## How to contact us
+
+If you have any questions about this privacy policy, the data we hold on you, or you would like to exercise one of your data protection rights, please do not hesitate to contact us using the e-mail icon in the footer of the site.

--- a/i18n/ca.toml
+++ b/i18n/ca.toml
@@ -11,6 +11,7 @@ projects = "projectes"
 about = "sobre mi"
 contact = "contacte"
 privacy = "política de privadesa"
+site_statistics = "estadístiques del lloc"
 sitemap = "mapa del lloc"
 
 # Navigation.

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -15,6 +15,7 @@ projects = "projekte"
 about = "über"
 contact = "kontakt"
 privacy = "datenschutzrichtlinie"
+site_statistics = "seitenstatistiken"
 sitemap = "seitenübersicht"
 
 # Navigation.

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -11,6 +11,7 @@ projects = "projects"
 about = "about"
 contact = "contact"
 privacy = "privacy policy"
+site_statistics = "site statistics"
 sitemap = "sitemap"
 
 # Navigation.

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -11,6 +11,7 @@ projects = "proyectos"
 about = "sobre mí"
 contact = "contacto"
 privacy = "política de privacidad"
+site_statistics = "estadísticas del sitio"
 sitemap = "mapa del sitio"
 
 # Navigation.

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -15,6 +15,7 @@ projects = "projets"
 about = "à propos"
 contact = "contact"
 privacy = "politique de confidentialité"
+site_statistics = "statistiques du site"
 sitemap = "plan du site"
 
 # Navigation.

--- a/i18n/hi.toml
+++ b/i18n/hi.toml
@@ -13,6 +13,7 @@ projects = "परियोजनाएं"
 about = "बारे में"
 contact = "संपर्क"
 privacy = "गोपनीयता नीति"
+site_statistics = "साइट सांख्यिकी"
 sitemap = "साइटमैप"
 
 # Navigation.

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -11,6 +11,7 @@ projects = "progetti"
 about = "chi sono"
 contact = "contatto"
 privacy = "politica sulla privacy"
+site_statistics = "statistiche del sito"
 sitemap = "mappa del sito"
 
 # Navigation.

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -15,6 +15,7 @@ projects = "プロジェクト"
 about = "自己紹介"
 contact = "お問い合わせ"
 privacy = "プライバシーポリシー"
+site_statistics = "サイト統計"
 sitemap = "サイトマップ"
 
 # Navigation.

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -15,6 +15,7 @@ projects = "프로젝트"
 about = "소개"
 contact = "연락처"
 privacy = "개인정보 처리방침"
+site_statistics = "사이트 통계"
 sitemap = "사이트맵"
 
 # Navigation.

--- a/i18n/pt-PT.toml
+++ b/i18n/pt-PT.toml
@@ -11,6 +11,7 @@ projects = "projetos"
 about = "sobre"
 contact = "contacto"
 privacy = "política de privacidade"
+site_statistics = "estatísticas do site"
 sitemap = "mapa do site"
 
 # Navigation.

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -11,6 +11,7 @@ projects = "проекты"
 about = "обо мне"
 contact = "контакт"
 privacy = "политика конфиденциальности"
+site_statistics = "статистика сайта"
 sitemap = "карта сайта"
 
 # Navigation.

--- a/i18n/uk.toml
+++ b/i18n/uk.toml
@@ -15,6 +15,7 @@ projects = "проєкти"
 about = "про мене"
 contact = "контакт"
 privacy = "політика конфіденційності"
+site_statistics = "статистика сайту"
 sitemap = "карта сайту"
 
 # Navigation.

--- a/i18n/zh-Hans.toml
+++ b/i18n/zh-Hans.toml
@@ -11,6 +11,7 @@ projects = "项目"
 about = "关于"
 contact = "联系方式"  # Machine translated.
 privacy = "隐私政策"  # Machine translated.
+site_statistics = "网站统计"  # Machine translated.
 sitemap = "站点地图"  # Machine translated.
 
 # Navigation.

--- a/i18n/zh-Hant.toml
+++ b/i18n/zh-Hant.toml
@@ -11,6 +11,7 @@ projects = "專案"
 about = "關於"
 contact = "聯絡方式"  # Machine translated.
 privacy = "隱私政策"  # Machine translated.
+site_statistics = "網站統計"  # Machine translated.
 sitemap = "網站地圖"  # Machine translated.
 
 # Navigation.


### PR DESCRIPTION
I'm making two important updates to the tabi demo site with the aim to improve the project while maintaining transparency and respecting user privacy.

## **Adding GoatCounter Analytics**

To better understand how users interact with the demo site, I'm implementing GoatCounter, an open-source and privacy-friendly analytics tool. The data collected will be non-identifiable and solely aimed at providing insights for improving user experience.

- **Self-Hosted GoatCounter analytics**.
- **Public Dashboard**: I'm introducing a public dashboard, accessible [here](https://tabi-stats.osc.garden/), to share the same insights with the community. In other words: all data collected is 100% public.

## **New Privacy Policy**

I'm also introducing a new Privacy Policy, explaining how the data is collected (for analytics and comments).

The privacy policy has been designed to be comprehensive and transparent. You can read it [here](https://welpo.github.io/tabi/privacy/).

## **Benefits**

- Improved understanding of user needs and behaviour. It could help in detecting missing translations that would benefit a large group of potential users; decide whether a mobile or desktop focus should take precedence; and provide data-based answers to "should we support this old browser?" or "is it a good idea to use this new feature for browsers?".
- Greater project transparency.
- Clear guidelines on data collection and usage.

---

I'm committed to transparency.

I'm also open to changing my mind about the analytics—I did a lot of thinking before opting in favour.

I'm 100% against tracking, but I think analytics, through GoatCounter, with no data shared with any third parties and no identifiable information stored, are both ethical and potentially benefitial to the tabi project.

I value community input and would love to hear any thoughts, concerns, or suggestions you may have regarding this update. Feel free to comment on this PR or reach out directly.