### PR TITLE
✨ feat(feed): support hiding pages or sections

### DIFF
--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuració de tabi: guia completa"
 date = 2023-09-18
-updated = 2023-11-24
+updated = 2023-12-04
 description = "Descobreix les múltiples maneres en què pots personalitzar tabi."
 
 [taxonomies]
@@ -441,6 +441,14 @@ Per obtenir més informació, incloent instruccions sobre com crear un subconjun
 |   ❌   |   ❌   |      ✅       |         ❌          |         ❌          |
 
 Per defecte, el feed Atom només conté el resum o descripció de les teves publicacions. Pots incloure el contingut complet de les publicacions establint `full_content_in_feed = true` a `config.toml`.
+
+### Amagar contingut del feed
+
+| Pàgina | Secció | `config.toml` | Segueix la jerarquia | Requereix JavaScript |
+|:----:|:-------:|:-------------:|:-----------------:|:-------------------:|
+|  ✅  |   ✅    |      ✅       |         ✅        |         ❌          |
+
+Pots amagar pàgines específiques o seccions senceres del feed amb `hide_from_feed = true`.
 
 ### Comentaris {#afegir-comentaris}
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuración de tabi: guía completa"
 date = 2023-09-18
-updated = 2023-11-24
+updated = 2023-12-04
 description = "Descubre las múltiples maneras en que puedes personalizar tabi."
 
 [taxonomies]
@@ -439,6 +439,14 @@ Para obtener más información, incluyendo instrucciones sobre cómo crear un su
 |   ❌   |   ❌    |      ✅       |        ❌       |         ❌          |
 
 Por defecto, el feed Atom solo contiene el resumen/descripción de tus publicaciones. Puedes incluir el contenido completo de las publicaciones estableciendo `full_content_in_feed = true` en `config.toml`.
+
+### Ocultar contenido del feed
+
+| Página | Sección | `config.toml` | Sigue la jerarquía | Requiere JavaScript |
+|:----:|:-------:|:-------------:|:-----------------:|:-------------------:|
+|  ✅  |   ✅    |      ✅       |         ✅        |         ❌          |
+
+Puedes ocultar páginas específicas o secciones enteras del feed con `hide_from_feed = true`.
 
 ### Comentarios {#añadir-comentarios}
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Mastering tabi Settings: A Comprehensive Guide"
 date = 2023-09-18
-updated = 2023-11-24
+updated = 2023-12-04
 description = "Discover the many ways you can customise your tabi site."
 
 [taxonomies]
@@ -443,6 +443,14 @@ For more information, including instructions on how to create a custom subset, s
 |  ❌  |   ❌    |      ✅       |         ❌        |         ❌          |
 
 By default, the Atom feed only contains the summary/description of your posts. You can include the entire posts' content by setting `full_content_in_feed = true` in `config.toml`.
+
+### Hiding Content from Feed
+
+| Page | Section | `config.toml` | Follows Hierarchy | Requires JavaScript |
+|:----:|:-------:|:-------------:|:-----------------:|:-------------------:|
+|  ✅  |   ✅    |      ✅       |         ✅        |         ❌          |
+
+You can hide specific pages or entire sections from your feed by setting `hide_from_feed = true`.
 
 ### Comments {#adding-comments}
 

--- a/content/pages/_index.ca.md
+++ b/content/pages/_index.ca.md
@@ -1,4 +1,7 @@
 +++
 render = false
 insert_anchor_links = "left"
+
+[extra]
+hide_from_feed = true
 +++

--- a/content/pages/_index.es.md
+++ b/content/pages/_index.es.md
@@ -1,4 +1,7 @@
 +++
 render = false
 insert_anchor_links = "left"
+
+[extra]
+hide_from_feed = true
 +++

--- a/content/pages/_index.md
+++ b/content/pages/_index.md
@@ -1,4 +1,7 @@
 +++
 render = false
 insert_anchor_links = "left"
+
+[extra]
+hide_from_feed = true
 +++

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -1,4 +1,5 @@
 {%- import "macros/translate.html" as macros_translate -%}
+{%- import "macros/settings.html" as macros_settings -%}
 {#- Load the internationalisation data -#}
 {%- set language_strings = load_data(path="i18n/" ~ lang ~ '.toml', required=false) -%}
 {%- if not language_strings -%}
@@ -44,6 +45,9 @@
     <updated>{{ last_updated | date(format="%+") }}</updated>
     <id>{{ feed_url | safe }}</id>
     {%- for page in pages %}
+    {%- if macros_settings::evaluate_setting_priority(setting="hide_from_feed", page=page, default_global_value=false) == "true" -%}
+        {%- continue -%}
+    {%- endif -%}
     <entry xml:lang="{{ page.lang }}">
         <title>{{ page.title }}</title>
         <published>{{ page.date | date(format="%+") }}</published>


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

This PR adds a variable `hide_from_feed` to hide pages and sections from the atom feed. This setting follows the hierarchy (see [docs](https://welpo.github.io/tabi/blog/mastering-tabi-settings/#settings-hierarchy)).

This is useful to hide content like an "about" page, the privacy policy…

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [X] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [X] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [X] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [X] Updated "Mastering tabi" post in English
  - [X] (Optional) Updated "Mastering tabi" post in Spanish
  - [X] (Optional) Updated "Mastering tabi" post in Catalan
