### PR TITLE
✨ feat: add taxonomy list and single term templates

### DIFF
--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -1,0 +1,42 @@
+{% extends "index.html" %}
+
+{% block main_content %}
+
+{%- set title = macros_translate::translate(key=taxonomy.name, default=taxonomy.name, language_strings=language_strings) -%}
+
+{{ macros_page_header::page_header(title=title)}}
+
+{% set tag_count = terms | length %}
+<div id="tag-cloud" class="{% if tag_count > 16 %}three-columns{% elif tag_count > 8 %}two-columns{% endif %}">
+    <ul class="tags">
+        {%- for term in terms -%}
+            <li class="tags-item">
+                {% if config.extra.compact_tags %}
+                    {# Shows the number of posts per tag as a superscript #}
+                    <a href="{{ term.permalink | safe }}"
+                       aria-label="{{ term.name }} – 
+                        {{ term.pages | length }} 
+                        {% if term.pages | length == 1 -%}
+                            {{- macros_translate::translate(key="post", default="post", language_strings=language_strings) -}}
+                        {%- else -%}
+                            {{- macros_translate::translate(key="posts", default="posts", language_strings=language_strings) -}}
+                        {%- endif -%}">
+                        {{ term.name }}
+                    </a> <sup>{{ term.pages | length }}</sup>
+                {% else %}
+                    <a href="{{ term.permalink | safe }}">
+                        {{ term.name }}</a>
+                        – {{ term.pages | length }}{%- if term.pages | length == 1 %}
+                        {# Only one post. Singular. #}
+                            {{- macros_translate::translate(key="post", default="post", language_strings=language_strings) -}}
+                        {% elif term.pages | length > 1 %}
+                        {# More than one post per tag. Plural. #}
+                            {{- macros_translate::translate(key="posts", default="posts", language_strings=language_strings) -}}
+                        {%- endif -%}
+                {% endif %}
+            </li>
+        {%- endfor -%}
+    </ul>
+</div>
+
+{% endblock main_content %}

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -1,0 +1,16 @@
+{% extends "index.html" %}
+
+{% block main_content %}
+
+{{ macros_page_header::page_header(title=term.name) }}
+
+{% set max = section.extra.max_posts | default(value=999999) %}
+{{ macros_list_posts::list_posts(posts=term.pages, max=max) }}
+
+<ul class="pagination">
+    <li class="page-item">
+        <a class="all-tags" href="{{ get_url(path="tags", lang=lang) }}/">←&nbsp;{{- macros_translate::translate(key=taxonomy.name, default=taxonomy.name, language_strings=language_strings) -}}</a>
+    </li>
+</ul>
+
+{% endblock main_content %}


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

This PR adds fallback/default templates for taxonomies other than tags.

### Related issue

Resolves #229.

## Changes

The changes include the addition of two new fallback templates:
- `taxonomy_list.html`.
- `taxonomy_single.html`.

Docs: https://www.getzola.org/documentation/templates/taxonomies/

Useful for users who might need taxonomies other than the default, tags.

The taxonomy terms can be translated if the user adds the necessary lines in their `i18n` folder. It falls back to the taxonomy name.

## Accessibility

Remains teh same as the default tags page(s).

### Type of change

- [x] New feature (adds non-breaking functionality)
- [ ] Bug fix (fixes an issue without altering functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [X] I have verified the accessibility of my changes
- [X] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan