### PR TITLE
✨ feat(archive): allow multiple sources in Archive

### DIFF
--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -235,16 +235,27 @@ Quan un usuari faci clic a la imatge o al títol d'un projecte, serà portat a l
 
 La pàgina del projecte individual es renderitza amb la plantilla predeterminada, tret que estableixis una altra, per exemple, `template = "info-page.html"`.
 
-### Archivo
+### Arxiu
 
-Agregar una página de archivo es similar a agregar una página de proyectos. Puedes crear un directorio en `content/archive/`. Allí, puedes crear un archivo `_index.md` con el siguiente bloque de metadatos:
+Afegir una pàgina d'arxiu és similar a afegir una pàgina de projectes. Pots crear un directori a `content/archive/`. Allà, pots crear un fitxer `_index.md` amb el següent encapçalament:
 
 ```toml
-title = "Archivo"
+title = "Arxiu"
 template = "archive.html"
 ```
 
-De forma predeterminada, el archivo listará las publicaciones ubicadas en `/blog/`. Si deseas cambiar esto, puedes establecer `section_path = "/otra-ruta/"` en la sección `[extra]` del archivo `_index.md`. Asegúrate de incluir la barra inclinada al final.
+Per defecte, l'arxiu llistarà les publicacions situades a `blog/`. Per personalitzar això, pots modificar la secció `[extra]` de l'arxiu `_index.md`:
+
+- **Per a un sol directori**: Estableix `section_path = "directori/"` per llistar publicacions d'un directori específic. Assegura't d'incloure la barra inclinada al final.
+
+- **Per a múltiples directoris**: Si vols agregar publicacions de diversos directoris, especifica la llista a `section_path`. Per exemple:
+
+  ```toml
+  [extra]
+  section_path = ["blog/", "notes/", "camí-tres/"]
+  ```
+
+**Nota**: la pàgina d'arxiu només llistarà publicacions que tinguin una data al seu encapçalament.
 
 ### Etiquetes
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -235,14 +235,25 @@ La página del proyecto individual se renderiza con la plantilla predeterminada,
 
 ### Archivo
 
-Agregar una página de archivo es similar a agregar una página de proyectos. Puedes crear un directorio en `content/archive/`. Allí, puedes crear un archivo `_index.md` con el siguiente bloque de metadatos:
+Agregar una página de archivo es similar a agregar una página de proyectos. Puedes crear un directorio en `content/archive/`. Allí, puedes crear un archivo `_index.md` con el siguiente encabezado:
 
 ```toml
 title = "Archivo"
 template = "archive.html"
 ```
 
-De forma predeterminada, el archivo listará las publicaciones ubicadas en `/blog/`. Si deseas cambiar esto, puedes establecer `section_path = "/otra-ruta/"` en la sección `[extra]` del archivo `_index.md`. Asegúrate de incluir la barra inclinada al final.
+Por defecto, el archivo mostrará las publicaciones ubicadas en `blog/`. Para personalizar esto, puedes modificar la sección `[extra]` del archivo `_index.md`:
+
+- **Para una sola ruta**: Establece `section_path = "tu-ruta/"` para listar publicaciones de un directorio específico. Asegúrate de incluir la barra inclinada al final.
+
+- **Para múltiples rutas**: Si deseas agregar publicaciones de varios directorios, `section_path` puede especificarse como una lista de rutas. Por ejemplo:
+
+  ```toml
+  [extra]
+  section_path = ["blog/", "notas/", "ruta-tres/"]
+  ```
+
+**Nota**: la página de Archivo sólo listará publicaciones con fecha.
 
 ### Etiquetas
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -244,7 +244,18 @@ title = "Archive"
 template = "archive.html"
 ```
 
-By default, the archive will list posts located in `/blog/`. If you'd like to change this, you can set `section_path = "/another-path/"` in the `[extra]` section of the `_index.md` file. Make sure to include the trailing slash.
+By default, the archive will list posts located in `blog/`. To customise this, you can modify the `[extra]` section of the `_index.md` file:
+
+- **For a single source path**: Set `section_path = "your-path/"` to list posts from a specific directory. Make sure to include the trailing slash.
+
+- **For multiple source paths**: If you want to aggregate posts from various directories, `section_path` can be specified as a list of paths. For example:
+
+  ```toml
+  [extra]
+  section_path = ["blog/", "notes/", "path-three/"]
+  ```
+
+**Note**: the Archive page will only list posts that have a date in their front matter.
 
 ### Tags
 

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -9,16 +9,24 @@
 
 <div class="archive">
     <ul class="list-with-title">
-        {%- set section_path = section.extra.section_path | default(value="blog/") -%}
-        {%- if lang == config.default_language %}
-            {%- set section_item = get_section(path=section_path ~ "_index.md") %}
-        {%- else %}
-            {%- set section_item = get_section(path=section_path ~ "_index." ~ lang ~ ".md") %}
+        {%- set source_paths = section.extra.section_path | default(value="blog/") -%}
+        {%- if source_paths is iterable -%}
+            {%- set paths = source_paths -%}
+        {%- else -%}
+            {%- set paths = [source_paths] -%}
         {%- endif %}
+        {%- set all_posts = [] -%}
+        {%- for path in paths -%}
+            {%- if lang == config.default_language %}
+                {%- set section_item = get_section(path=path ~ "_index.md") -%}
+            {%- else %}
+                {%- set section_item = get_section(path=path ~ "_index." ~ lang ~ ".md") -%}
+            {%- endif %}
+            {%- set_global all_posts = all_posts | concat(with=section_item.pages) -%}
+        {%- endfor %}
 
-        {% for year, posts in
-        section_item.pages | group_by(attribute="year") %} {% if posts | length > 0
-        %}
+        {% for year, posts in all_posts | group_by(attribute="year") %}
+        {% if posts | length > 0 %}
         <li>
             <h2 class="listing-title">{{ year }}</h2>
             <ul class="listing">
@@ -29,13 +37,13 @@
                             {{ post.date | date(format="%d %b", locale=date_locale) }}
                         </span>
                     </div>
-                    <a href="{{ post.permalink }}" title="{{ post.title }}"
-                        >{{ post.title }}</a>
+                    <a href="{{ post.permalink }}" title="{{ post.title }}">{{ post.title }}</a>
                 </li>
                 {% endfor %}
             </ul>
-            {% endif %} {% endfor %}
         </li>
+        {% endif %}
+        {% endfor %}
     </ul>
 </div>
 


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

This PR introduces the capability to configure a multi-sourced archive page. Previously, the theme only supported archives from a single source (like `blog/`). Now, users can specify multiple sources in their configuration.

### Related issue

Resolves #245.

## Changes

Modified the Tera template for archives to accept either a single source path or an array of source paths. In the archive page, users can configure:

- **For a single source path**: Set `section_path = "your-path/"` to list posts from a specific directory. Make sure to include the trailing slash.

- **For multiple source paths**: If you want to aggregate posts from various directories, `section_path` can be specified as a list of paths. For example:

  ```toml
  [extra]
  section_path = ["blog/", "notes/", "path-three/"]
  ```

### Accessibility

No changes.

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [X] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [X] I have verified the accessibility of my changes
- [X] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [X] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [X] Updated "Mastering tabi" post in English
  - [X] (Optional) Updated "Mastering tabi" post in Spanish
  - [X] (Optional) Updated "Mastering tabi" post in Catalan
