### PR TITLE
💥 deprecate(home-banner)!: force proper header.img path

### DIFF
--- a/templates/partials/home_banner.html
+++ b/templates/partials/home_banner.html
@@ -7,11 +7,9 @@
         </section>
     </div>
     {%- if header.img -%}
-        {# Check if the image contains "$BASE_URL". This feature will be removed in the future #} {# in favour of using the proper image path. It will be a breaking change. #}
         {%- if header.img is containing("$BASE_URL") -%}
-            {%- set image_path = header.img | replace(from="$BASE_URL", to=config.base_url) | safe -%}
-            {# When the feature is removed, uncomment below to throw a descriptive error #}
-            {# {{ throw(message="ERROR: The image path for the header should not contain '$BASE_URL'. Please remove it and use the proper image path.") }} #}
+            {# Conversion no longer supported in favour of proper path. #}
+            {{ throw(message="ERROR: The image path for the header should not contain '$BASE_URL'. Please remove it and use the proper image path.") }}
         {%- else -%}
             {%- set image_path = get_url(path=header.img, trailing_slash=false) | safe -%}
         {%- endif -%}


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Removes support for converting `$BASE_URL` in the main page header (`header.img`) to config's `base_url`.

Users should instead use the actual image path for the `header.img` variable.

### Related issue

Deprecation mentioned in #123.