### PR TITLE
💥 deprecate(i18n)!: force config.toml copyright translation

### DIFF
--- a/templates/partials/copyright.html
+++ b/templates/partials/copyright.html
@@ -7,9 +7,7 @@
         {%- endif -%}
     {%- elif config.extra.translate_copyright -%}
         {# Old way to translate the copyright through toml files #}
-        {# When the feature is removed, uncomment below to throw a descriptive error #}
-        {# {{ throw(message="ERROR: The 'translate_copyright' feature has been deprecated. Please set 'copyright_translations' in config.toml. See the documentation: https://welpo.github.io/tabi/blog/mastering-tabi-settings/#copyright") }} #}
-        {% set copyright = macros_translate::translate(key="copyright", default=config.extra.copyright, language_strings=language_strings) %}
+        {{ throw(message="ERROR: The 'translate_copyright' feature has been deprecated. Please set 'copyright_translations' in config.toml. See the documentation: https://welpo.github.io/tabi/blog/mastering-tabi-settings/#copyright") }}
     {%- endif -%}
 
     {# Check for missing variables in the notice #}


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Removes support for translating copyright strings through i18n toml files.

Users should configure the corresponding translation in `copyright_translations.{language_code}` for each language they want to support, as [explained in the docs](https://welpo.github.io/tabi/blog/mastering-tabi-settings/#copyright). Example:

```toml
copyright_translations.es = "© $CURRENT_YEAR $AUTHOR $SEPARATOR A menos que se indique lo contrario, el contenido de esta web está disponible bajo la licencia [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)."
```

### Related issue

Discussed in #214 and added the new translation feature in #215.