### PR TITLE
fix: switch previous/next article links position

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -138,13 +138,13 @@
                 {% endif %}
             <nav class="{{ full_width_class | default(value="") }} article-navigation">
                 <div>
-                {%- if page.lower -%}
-                <a href="{{ page.lower.permalink | safe }}">&#8249; {{ page.lower.title | truncate(length=100) }}</a>
+                {%- if page.higher -%}
+                <a href="{{ page.higher.permalink | safe }}">&#8249; {{ page.higher.title | truncate(length=100) }}</a>
                 {%- endif -%}
                 </div>
                 <div>
-                {%- if page.higher -%}
-                <a href="{{ page.higher.permalink | safe }}"> {{ page.higher.title | truncate(length=100) }} &#8250;</a>
+                {%- if page.lower -%}
+                <a href="{{ page.lower.permalink | safe }}"> {{ page.lower.title | truncate(length=100) }} &#8250;</a>
                 {%- endif -%}
                 </div>
             </nav>


### PR DESCRIPTION


<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Put previous article link on the left and next on the right.
I tested it for both main site and translation using tabi demo site.

### Related issue

- #259 

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [X] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] ~~I have verified the accessibility of my changes~~
- [X] I have tested all possible scenarios for this change
- [ ] ~~I have updated `theme.toml` with a sane default for the feature~~
- [ ] ~~I have made corresponding changes to the documentation:~~
  - [ ] ~~Updated `config.toml` comments~~
  - [ ] ~~Updated `theme.toml` comments~~
  - [ ] ~~Updated "Mastering tabi" post in English~~
  - [ ] ~~(Optional) Updated "Mastering tabi" post in Spanish~~
  - [ ] ~~(Optional) Updated "Mastering tabi" post in Catalan~~
