### PR TITLE
✨ feat(i18n): add Right-to-left script support

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,7 @@ This variable will hold all the text strings for the language #}
 {%- if not language_strings -%}
     {%- set language_strings = load_data(path="themes/tabi/i18n/" ~ lang ~ ".toml", required=false) -%}
 {%- endif -%}
+{% set_global rtl_langs = ["ar","arc","az","dv","ff","he","ku","nqo","fa","rhg","syc","ur"] %}
 
 
 <!DOCTYPE html>
@@ -22,7 +23,7 @@ This variable will hold all the text strings for the language #}
 
 {% include "partials/header.html" %}
 
-<body>
+<body {% if lang in rtl_langs %} dir="rtl" {% endif %}>
     {% include "partials/nav.html" %}
     <div class="content">
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,7 @@ This variable will hold all the text strings for the language #}
 {%- if not language_strings -%}
     {%- set language_strings = load_data(path="themes/tabi/i18n/" ~ lang ~ ".toml", required=false) -%}
 {%- endif -%}
-{% set_global rtl_langs = ["ar","arc","az","dv","ff","he","ku","nqo","fa","rhg","syc","ur"] %}
+{% set rtl_languages = ["ar", "arc", "az", "dv", "ff", "he", "ku", "nqo", "fa", "rhg", "syc", "ur"] %}
 
 
 <!DOCTYPE html>
@@ -23,7 +23,7 @@ This variable will hold all the text strings for the language #}
 
 {% include "partials/header.html" %}
 
-<body {% if lang in rtl_langs %} dir="rtl" {% endif %}>
+<body{% if lang in rtl_languages %} dir="rtl"{% endif %}>
     {% include "partials/nav.html" %}
     <div class="content">
 


### PR DESCRIPTION
Add support for RTL languages, such as Arabic and Hebrew, by adding the `dir` attribute to the `body` tag if the language is RTL.

### What changes did you make?
I added the `extra.rtl` and `extra.lang_rtl.<lang>` to the config, with this change, we can specify the languages that are RTL and the `dir` attribute will be added to the `body` tag.