### PR TITLE
🐛 fix(i18n): atom feed page direction for RTL langs

### DIFF
--- a/static/feed_style.xsl
+++ b/static/feed_style.xsl
@@ -15,7 +15,7 @@
         <link rel="stylesheet" href="{/atom:feed/atom:link[@rel='extra-stylesheet']/@href}" />
 
       </head>
-     <body dir="auto">
+      <body dir="auto">
         <div class="content">
           <main>
             <div class="info-box">

--- a/static/feed_style.xsl
+++ b/static/feed_style.xsl
@@ -15,7 +15,7 @@
         <link rel="stylesheet" href="{/atom:feed/atom:link[@rel='extra-stylesheet']/@href}" />
 
       </head>
-      <body>
+     <body dir="auto">
         <div class="content">
           <main>
             <div class="info-box">


### PR DESCRIPTION
Fix https://github.com/welpo/tabi/issues/267


The page will looks like this after this PR

> [!NOTE]
> I change the language from English to Arabic, to see the page in `LTR` and `RTL`

https://github.com/welpo/tabi/assets/59842932/a7575de0-fa67-4c09-aa1d-b4fae813a759


