### PR TITLE
🚧 feat: proof of concept pluralization

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,14 +5,14 @@ author = "welpo"
 generate_feed = true
 compile_sass = true
 minify_html = true
-build_search_index = true
+# build_search_index = true
 
 # To translate the entire theme, there must be a file with the same ISO 639-1
 # (or IETF BCP 47) Code in the `i18n` folder of your site or the tabi theme
 # For example, "i18n/fr.toml" for French or "i18n/zh-Hans.toml" for Simplified Chinese.
 # Otherwise the theme will be in English.
 # See https://welpo.github.io/tabi/blog/faq-languages/ for more details.
-default_language = "en"
+default_language = "ar"
 
 taxonomies = [{name = "tags", feed = true}]
 

--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -1,3 +1,9 @@
+# Proof of concept for pluralisation:
+one_read_minute = "دقيقة واحدة"
+two_read_minute = "دقيقتان"
+few_read_minute = "$MINUTES دقائق"
+many_read_minute = "$MINUTES دقيقة"
+
 # Hello, the Arabic language has many pronouns and words, and each word indicates a different meaning,
 # unlike the English language, in which, on the other hand, the word can refer to a person and a group.
 # This translation is for individual use, if you are a company or organization, I have put a comment in

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,3 +1,8 @@
+# Proof of concept for pluralisation:
+one_read_minute = "$MINUTES min read"
+many_read_minute = "$MINUTES min read (plural; it's the same)"
+
+
 language_name = "English"  # Shown in language picker for multi-language sites.
 date_locale = "en_GB"
 full_stop = "."  # Used at the end of a sentence.

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,7 @@
 {% import "macros/format_date.html" as macros_format_date %}
 {% import "macros/list_posts.html" as macros_list_posts %}
 {% import "macros/page_header.html" as macros_page_header %}
+{% import "macros/pluralize.html" as macros_pluralize %}
 {% import "macros/rel_attributes.html" as macros_rel_attributes %}
 {% import "macros/settings.html" as macros_settings %}
 {% import "macros/table_of_contents.html" as macros_toc %}

--- a/templates/macros/pluralize.html
+++ b/templates/macros/pluralize.html
@@ -1,0 +1,32 @@
+{% macro pluralize(language="en", number) %}
+    {%- set key_prefix = "" -%}
+    {%- if language == "ar" -%}
+        {# Arabic-specific pluralization rules #}
+        {%- set modulo = number % 100 -%}
+        {%- if number > 100 -%}
+            {%- if modulo == 0 or modulo == 1 or modulo == 2 -%}
+                {%- set key_prefix = "special_" -%} {# Sixth form for numbers above 100 ending with 0, 1, or 2 #}
+            {%- endif -%}
+        {%- elif number == 0 -%}
+            {%- set key_prefix = "zero_" -%} {# First form for 0 #}
+        {%- elif number == 1 -%}
+            {%- set key_prefix = "one_" -%} {# Second form for 1 #}
+        {%- elif number == 2 -%}
+            {%- set key_prefix = "two_" -%} {# Third form for 2 #}
+        {%- elif modulo >= 3 and modulo <= 10 -%}
+            {%- set key_prefix = "few_" -%} {# Fourth form for numbers ending 3-10 #}
+        {%- elif modulo >= 11 and modulo <= 99 -%}
+            {%- set key_prefix = "many_" -%} {# Fifth form for numbers ending 11-99 #}
+        {%- else -%}
+            {%- set key_prefix = "other_" -%} {# Catch-all for any other cases #}
+        {%- endif -%}
+    {%- else -%}
+        {# Default pluralization logic for languages other than Arabic #}
+        {%- if number == 1 -%}
+            {%- set key_prefix = "one_" -%}
+        {%- else -%}
+            {%- set key_prefix = "many_" -%}
+        {%- endif -%}
+    {%- endif -%}
+    {{- key_prefix -}}
+{% endmacro %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -12,6 +12,43 @@
 {%- endif -%}
 
 {# Debugging #}
+{%- set count = 11 -%} {# Replace this to test #}
+{%- set base_key = "read_minute" -%}
+{%- set prefix = macros_pluralize::pluralize(lang=lang, number=count) -%}
+{%- set full_key = prefix ~ base_key -%}
+{%- set translated_key = macros_translate::translate(key=full_key, language_strings=language_strings, default="couldn't find the string") -%}
+{%- set processed_key = translated_key | replace(from="$MINUTES", to=count | as_str) -%}
+<table>
+    <thead>
+        <tr>
+            <th>Variable</th>
+            <th>Value</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>count</code></td>
+            <td>{{ count }}</td>
+            <td>The number of minutes used for testing.</td>
+        </tr>
+        <tr>
+            <td><code>full_key</code></td>
+            <td>{{ full_key }}</td>
+            <td>Constructed key for fetching the translation.</td>
+        </tr>
+        <tr>
+            <td><code>translated_key</code></td>
+            <td>{{ translated_key }}</td>
+            <td>The raw translation fetched using <code>full_key</code>.</td>
+        </tr>
+        <tr>
+            <td><code>processed_key</code></td>
+            <td>{{ processed_key }}</td>
+            <td>The final translation after replacing <code>$MINUTES</code> with the actual count.</td>
+        </tr>
+    </tbody>
+</table>
 {# {% set last_ancestor = page.ancestors | slice(start=-1) %}
 {% set current_section = get_section(path=last_ancestor.0) %}
 


### PR DESCRIPTION
Proof of concept pluralization for testing.

Discussion: #273

The logic to get the strings is in the macro `pluralize.html`.

To test:
* Set language to arabic (already done)
* Modify `templates/page.html` to change the `count` variable in the `Debugging` section
* Load any post to see a table with the values and translations:

![ss](https://github.com/welpo/tabi/assets/6399341/53553125-6ebf-4620-88b4-07683d2834fa)

🚨 **IMPORTANT**: when you change the TOML strings in `i18n`, you need to restart `zola serve` to use the updated strings.