### PR TITLE
✨ feat(homepage): allow hiding posts listing

### DIFF
--- a/templates/partials/main_page_posts_list.html
+++ b/templates/partials/main_page_posts_list.html
@@ -1,18 +1,20 @@
-<div id="posts-list">
-    <div>
-        {{ macros_page_header::page_header(title=section.title) }}
+{%- if paginator or extra_section -%}
+    <div id="posts-list">
+        <div>
+            {{ macros_page_header::page_header(title=section.title) }}
+        </div>
+
+        {%- if paginator %}
+            {%- set pages = paginator.pages -%}
+        {% else %}
+            {%- set pages = extra_section.pages -%}
+        {% endif -%}
+
+        {% set max_posts = section.extra.max_posts | default(value=999999) %}
+        {{ macros_list_posts::list_posts(posts=pages, max=max_posts, language_strings=language_strings, section_path=path) }}
     </div>
 
-    {%- if paginator %}
-        {%- set pages = paginator.pages -%}
-    {% else %}
-        {%- set pages = extra_section.pages -%}
-    {% endif -%}
-
-	{% set max_posts = section.extra.max_posts | default(value=999999) %}
-    {{ macros_list_posts::list_posts(posts=pages, max=max_posts, language_strings=language_strings, section_path=path) }}
-</div>
-
-{% if paginator %}
-    {%- include "partials/paginate.html" -%}
-{% endif %}
+    {% if paginator %}
+        {%- include "partials/paginate.html" -%}
+    {% endif %}
+{%- endif -%}

--- a/templates/section.html
+++ b/templates/section.html
@@ -9,7 +9,11 @@
     {%- set first_section = "posts" -%}
 {%- endif -%}
 
-<main class={{ first_section }}-first>
+{%- if section.extra.section_path or paginator and projects_path -%}
+    {%- set more_than_one_section_shown = true -%}
+{%- endif -%}
+
+<main {% if more_than_one_section_shown %}class="{{ first_section }}-first"{% endif %}>
 {%- if section.extra.header %}
     {%- include "partials/home_banner.html" -%}
 {% endif -%}


### PR DESCRIPTION
## Summary

Added the possibility of hiding posts on the main page.

To achieve this, do not set `paginate_by` nor `section_path` in the `[extra]` section of an `_index.md` file.

### Related issue

Resolves #316.

## Changes

- Added conditional logic to determine the order of displaying sections (projects or posts) on the main page.
- Updated the `<main>` tag to conditionally apply the appropriate CSS class based on the presence of sections.
- Included dynamic construction of template paths and used them for conditional inclusion of sections.

### Accessibility

No changes.

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [X] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [X] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
