### PR TITLE
⚡️ perf: getting the metadata only in this common operation speeds up my build 10 times

### DIFF
--- a/templates/macros/settings.html
+++ b/templates/macros/settings.html
@@ -16,7 +16,7 @@ Parameters:
 {%- elif page -%}
     {#- Retrieve last ancestor to determine current section, if applicable -#}
     {%- set last_ancestor = page.ancestors | slice(start=-1) %}
-    {%- set current_section = get_section(path=last_ancestor.0) %}
+    {%- set current_section = get_section(path=last_ancestor.0, metadata_only=true) %}
 {%- endif -%}
 
 {%- set priority_order = [


### PR DESCRIPTION
By requesting only the metadata in `get_section` this speeds up my build by a massive amount.

See #324
