### PR TITLE
✨ feat: add date visibility options to post list

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -146,6 +146,12 @@ show_reading_time = true
 # Can be set at page or section levels, following the hierarchy: page > section > config. See: https://welpo.github.io/tabi/blog/mastering-tabi-settings/#settings-hierarchy
 show_date = true
 
+# Determines how dates are displayed in the post listing (e.g. front page or /blog). Options:
+# "date" - Show only the original date of the post.
+# "updated" - Show only the last updated date of the post.
+# "both" - Show both the original date and the last updated date.
+post_listing_date = "both"
+
 # DEPRECATED!
 # Use Zola's built-in `bottom_footnotes = true` in the [markdown] section instead. (Available since v0.19.0)
 # Adds backlinks to footnotes (loads ~500 bytes of JavaScripts).

--- a/config.toml
+++ b/config.toml
@@ -147,10 +147,10 @@ show_reading_time = true
 show_date = true
 
 # Determines how dates are displayed in the post listing (e.g. front page or /blog). Options:
-# "date" - Show only the original date of the post.
+# "date" - Show only the original date of the post (default if unset).
 # "updated" - Show only the last updated date of the post.
 # "both" - Show both the original date and the last updated date.
-post_listing_date = "both"
+post_listing_date = "date"
 
 # DEPRECATED!
 # Use Zola's built-in `bottom_footnotes = true` in the [markdown] section instead. (Available since v0.19.0)

--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuració de tabi: guia completa"
 date = 2023-09-18
-updated = 2024-07-04
+updated = 2024-07-09
 description = "Descobreix les múltiples maneres en què pots personalitzar tabi."
 
 [taxonomies]
@@ -140,6 +140,14 @@ max_posts = 4
 Fixa't que si configures `section_path`, no cal que configuris `paginate_by`. Pots establir `max_posts` per determinar el nombre de publicacions que vols mostrar a la pàgina principal.
 
 El `title` és el títol que apareix a sobre de les publicacions.
+
+##### Mostrar la data dels articles al llistat
+
+Per defecte, quan es llisten els articles, es mostra la data de creació. Pots configurar quina(es) data(es) mostrar utilitzant l'opció `post_listing_date`. Configuracions disponibles:
+
+- `date`: Mostra només la data de publicació original de l'article (opció per defecte).
+- `updated`: Mostra només la data de l'última actualització de l'article.
+- `both`: Mostra tant la data de publicació original com la data de l'última actualització.
 
 #### Llistat de Projectes
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuración de tabi: guía completa"
 date = 2023-09-18
-updated = 2024-07-04
+updated = 2024-07-09
 description = "Descubre las múltiples maneras en que puedes personalizar tabi."
 
 [taxonomies]
@@ -140,6 +140,14 @@ max_posts = 4
 Fíjate que si configuras `section_path`, no necesitas configurar `paginate_by`. Puedes establecer `max_posts` para determinar el número de publicaciones que deseas mostrar en la página principal.
 
 El `title` es el encabezado que aparece sobre las publicaciones.
+
+##### Mostrar la fecha de los artículos en el listado
+
+Por defecto, cuando se listan los artículos, se muestra la fecha de creación. Puedes configurar qué fecha(s) mostrar usando la opción `post_listing_date`. Configuraciones disponibles:
+
+- `date`: Muestra solo la fecha de publicación original del artículo (opción por defecto).
+- `updated`: Muestra solo la fecha de la última actualización del artículo.
+- `both`: Muestra tanto la fecha de publicación original como la fecha de la última actualización.
 
 #### Listado de proyectos
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Mastering tabi Settings: A Comprehensive Guide"
 date = 2023-09-18
-updated = 2024-07-04
+updated = 2024-07-09
 description = "Discover the many ways you can customise your tabi site."
 
 [taxonomies]
@@ -140,6 +140,14 @@ max_posts = 4
 Notice how if you set `section_path`, you don't need to set `paginate_by`. You can set `max_posts` to the determine the number of posts you want to show on the main page.
 
 The `title` is the header that appears above the posts.
+
+##### Display the Date of Posts in Listing
+
+By default, when listing posts, the date of post creation is shown. You can configure which date(s) to display using the `post_listing_date` option. Available settings:
+
+- `date`: Show only the original date of the post (default).
+- `updated`: Show only the last updated date of the post.
+- `both`: Show both the original date and the last updated date.
 
 #### Listing Projects
 

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -276,6 +276,10 @@ video {
     margin-bottom: 2rem;
 }
 
+.mobile-only {
+    display: none;
+}
+
 @media only screen and (max-width: 1000px) {
     .content {
         max-width: var(--normal-layout-width);
@@ -291,6 +295,10 @@ video {
         margin-left: 0;
         max-width: none;
         overflow-x: auto;
+    }
+
+    .mobile-only {
+        display: block;
     }
 }
 

--- a/sass/parts/_posts_list.scss
+++ b/sass/parts/_posts_list.scss
@@ -10,6 +10,7 @@
     padding: 2.5rem 0;
 
     .bloglist-meta {
+        margin-right: 0.7rem;
         padding: 0;
         width: 13.5rem;
         color: var(--meta-color);

--- a/static/feed_style.xsl
+++ b/static/feed_style.xsl
@@ -19,40 +19,55 @@
         <div class="content">
           <main>
             <div class="info-box">
-                <!-- This block replaces the text "About Feeds" with a hyperlink in the translated string -->
-                <xsl:choose>
-                    <xsl:when test="contains(/atom:feed/str:translations/str:about_feeds, 'About Feeds')">
-                        <xsl:value-of select="substring-before(/atom:feed/str:translations/str:about_feeds, 'About Feeds')"/>
-                        <a href="https://aboutfeeds.com/" target="_blank">About Feeds</a>
-                        <xsl:value-of select="substring-after(/atom:feed/str:translations/str:about_feeds, 'About Feeds')"/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:value-of select="/atom:feed/str:translations/str:about_feeds"/>
-                    </xsl:otherwise>
-                </xsl:choose>
+              <!-- This block replaces the text "About Feeds" with a hyperlink in the translated string -->
+              <xsl:choose>
+                <xsl:when test="contains(/atom:feed/str:translations/str:about_feeds, 'About Feeds')">
+                  <xsl:value-of select="substring-before(/atom:feed/str:translations/str:about_feeds, 'About Feeds')"/>
+                  <a href="https://aboutfeeds.com/" target="_blank">About Feeds</a>
+                  <xsl:value-of select="substring-after(/atom:feed/str:translations/str:about_feeds, 'About Feeds')"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:value-of select="/atom:feed/str:translations/str:about_feeds"/>
+                </xsl:otherwise>
+              </xsl:choose>
             </div>
             <section id="banner-home-subtitle">
-            <div class="padding-top home-title">
+              <div class="padding-top home-title">
                 <xsl:value-of select="/atom:feed/atom:title"/>
-            </div>
-            <p>
-              <xsl:value-of select="/atom:feed/atom:subtitle"/>
-            </p>
-            <a class="readmore">
-              <xsl:attribute name="href">
-                <xsl:value-of select="/atom:feed/@xml:base"/>
-              </xsl:attribute>
-            <xsl:value-of select="/atom:feed/str:translations/str:visit_the_site" />&#160;<span class="arrow">→</span></a><p></p>
+              </div>
+              <p>
+                <xsl:value-of select="/atom:feed/atom:subtitle"/>
+              </p>
+              <a class="readmore">
+                <xsl:attribute name="href">
+                  <xsl:value-of select="/atom:feed/@xml:base"/>
+                </xsl:attribute>
+                <xsl:value-of select="/atom:feed/str:translations/str:visit_the_site" />&#160;<span class="arrow">→</span>
+              </a>
+              <p></p>
             </section>
-
             <div class="padding-top listing-title bottom-divider">
-            <h1><xsl:value-of select="/atom:feed/str:translations/str:recent_posts" /></h1>
+              <h1><xsl:value-of select="/atom:feed/str:translations/str:recent_posts" /></h1>
             </div>
+            <xsl:variable name="post_listing_date" select="/atom:feed/atom:post_listing_date"/>
             <div class="bloglist-container">
               <xsl:for-each select="/atom:feed/atom:entry">
                 <section class="bloglist-row bottom-divider">
                   <ul class="bloglist-meta">
-                    <li class="date"><xsl:value-of select="substring(atom:published, 0, 11)"/></li>
+                    <xsl:if test="$post_listing_date = 'date' or $post_listing_date = 'both'">
+                      <li class="date">
+                        <xsl:value-of select="substring(atom:published, 0, 11)"/>
+                      </li>
+                    </xsl:if>
+                    <xsl:if test="$post_listing_date = 'updated' or $post_listing_date = 'both'">
+                      <li class="date">
+                        <xsl:variable name="update_string" select="/atom:feed/str:translations/str:last_updated_on"/>
+                        <xsl:variable name="update_date" select="substring(atom:updated, 0, 11)"/>
+                        <xsl:value-of select="substring-before($update_string, '$DATE')"/>
+                        <xsl:value-of select="$update_date"/>
+                        <xsl:value-of select="substring-after($update_string, '$DATE')"/>
+                      </li>
+                    </xsl:if>
                   </ul>
                   <div class="bloglist-content">
                     <div class="bloglist-title">

--- a/static/feed_style.xsl
+++ b/static/feed_style.xsl
@@ -54,12 +54,22 @@
               <xsl:for-each select="/atom:feed/atom:entry">
                 <section class="bloglist-row bottom-divider">
                   <ul class="bloglist-meta">
-                    <xsl:if test="$post_listing_date = 'date' or $post_listing_date = 'both'">
+                    <xsl:variable name="show_date" select="$post_listing_date = 'date' or $post_listing_date = 'both'"/>
+                    <xsl:variable name="show_updated" select="$post_listing_date = 'updated' or $post_listing_date = 'both'"/>
+
+                    <xsl:if test="$show_date">
                       <li class="date">
                         <xsl:value-of select="substring(atom:published, 0, 11)"/>
                       </li>
                     </xsl:if>
-                    <xsl:if test="$post_listing_date = 'updated' or $post_listing_date = 'both'">
+
+                    <xsl:if test="$show_date and $show_updated">
+                      <li class="mobile-only">
+                        <xsl:value-of select="/atom:feed/str:translations/str:separator"/>
+                      </li>
+                    </xsl:if>
+
+                    <xsl:if test="$show_updated">
                       <li class="date">
                         <xsl:variable name="update_string" select="/atom:feed/str:translations/str:last_updated_on"/>
                         <xsl:variable name="update_date" select="substring(atom:updated, 0, 11)"/>

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -18,6 +18,9 @@
         <str:recent_posts>
             {{- macros_translate::translate(key="recent_posts", default="Recent posts", language_strings=language_strings) -}}
         </str:recent_posts>
+        <str:last_updated_on>
+            {{- macros_translate::translate(key="last_updated_on", default="Updated on $DATE", language_strings=language_strings) -}}
+        </str:last_updated_on>
     </str:translations>
 
     {#- Load extra CSS (skin) if set in config.toml -#}
@@ -34,6 +37,7 @@
         <subtitle>{{ config.description }}</subtitle>
     {%- endif %}
     <link href="{{ feed_url | safe }}" rel="self" type="application/atom+xml"/>
+    <post_listing_date>{{ config.extra.post_listing_date | default(value="date") }}</post_listing_date>
     <link href="
         {%- if section -%}
             {{ section.permalink | escape_xml | safe }}

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -9,6 +9,9 @@
 <?xml-stylesheet href="{{ get_url(path='/feed_style.xsl', trailing_slash=false) | safe }}" type="text/xsl"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:base="http://purl.org/atompub/base/1.0/" xml:lang="{{ lang }}" xml:base="{{ config.base_url }}">
     <str:translations xmlns:str="https://github.com/welpo/tabi">
+        <str:separator>
+            {{  config.extra.separator | default(value="•") }}
+        </str:separator>
         <str:about_feeds>
             {{- macros_translate::translate(key="about_feeds", default="This is a web feed, also known as an Atom feed. Subscribe by copying the URL from the address bar into your newsreader", language_strings=language_strings) -}}
         </str:about_feeds>

--- a/templates/macros/list_posts.html
+++ b/templates/macros/list_posts.html
@@ -14,8 +14,14 @@
             {% endif %}
 
             <ul class="bloglist-meta">
-                {%- set show_date = post.date and config.extra.post_listing_date == "date" or post.date and config.extra.post_listing_date == "both" -%}
-                {%- set show_updated = post.updated and config.extra.post_listing_date == "updated" or post.updated and config.extra.post_listing_date == "both" -%}
+                {%- set allowed_post_listing_dates = ["date", "updated", "both"] -%}
+                {%- set post_listing_date = config.extra.post_listing_date | default(value="date") -%}
+                {%- if post_listing_date not in allowed_post_listing_dates -%}
+                    {{ throw(message="ERROR: Invalid value for config.extra.post_listing_date. Allowed values are 'date', 'updated', or 'both'.") }}
+                {%- endif -%}
+
+                {%- set show_date = post.date and post_listing_date == "date" or post.date and post_listing_date == "both" -%}
+                {%- set show_updated = post.updated and post_listing_date == "updated" or post.updated and post_listing_date == "both" -%}
 
                 {%- if show_date or show_updated -%}
                     {%- if show_date -%}

--- a/templates/macros/list_posts.html
+++ b/templates/macros/list_posts.html
@@ -1,5 +1,7 @@
 {% macro list_posts(posts, max, language_strings="", section_path="blog") %}
 
+{%- set separator = config.extra.separator | default(value="•") -%}
+
 <div class="bloglist-container">
     {% for post in posts %}
         {% if loop.index <= max %}
@@ -12,9 +14,24 @@
             {% endif %}
 
             <ul class="bloglist-meta">
-                {% if post.date %}
-                <li class="date">{{ macros_format_date::format_date(date=post.date, short=false, language_strings=language_strings) }}</li>
-                {% endif %}
+                {%- set show_date = post.date and config.extra.post_listing_date == "date" or post.date and config.extra.post_listing_date == "both" -%}
+                {%- set show_updated = post.updated and config.extra.post_listing_date == "updated" or post.updated and config.extra.post_listing_date == "both" -%}
+
+                {%- if show_date or show_updated -%}
+                    {%- if show_date -%}
+                        <li class="date">{{- macros_format_date::format_date(date=post.date, short=false, language_strings=language_strings) -}}</li>
+                    {%- endif -%}
+                    {%- if show_date and show_updated -%}
+                        <li class="mobile-only">{{- separator -}}</li>
+                    {%- endif -%}
+                    {%- if show_updated -%}
+                        {%- set last_updated_str = macros_translate::translate(key="last_updated_on", default="Updated on $DATE", language_strings=language_strings) -%}
+                        {%- set formatted_date = macros_format_date::format_date(date=post.updated, short=true, language_strings=language_strings) -%}
+                        {%- set updated_str = last_updated_str | replace(from="$DATE", to=formatted_date) -%}
+                        <li class="date">{{ updated_str }}</li>
+                    {%- endif -%}
+                {%- endif -%}
+
                 {% if post.draft %}
                 <li class="draft-label">{{ macros_translate::translate(key="draft", default="DRAFT", language_strings=language_strings) }}</li>
                 {% endif %}

--- a/theme.toml
+++ b/theme.toml
@@ -104,7 +104,7 @@ show_reading_time = true
 show_date = true
 
 # Determines how dates are displayed in the post listing (e.g. front page or /blog). Options:
-# "date" - Show only the original date of the post.
+# "date" - Show only the original date of the post (default if unset).
 # "updated" - Show only the last updated date of the post.
 # "both" - Show both the original date and the last updated date.
 post_listing_date = "date"

--- a/theme.toml
+++ b/theme.toml
@@ -103,6 +103,12 @@ show_reading_time = true
 # Can be set at page or section levels, following the hierarchy: page > section > config. See: https://welpo.github.io/tabi/blog/mastering-tabi-settings/#settings-hierarchy
 show_date = true
 
+# Determines how dates are displayed in the post listing (e.g. front page or /blog). Options:
+# "date" - Show only the original date of the post.
+# "updated" - Show only the last updated date of the post.
+# "both" - Show both the original date and the last updated date.
+post_listing_date = "date"
+
 # DEPRECATED!
 # Use Zola's built-in `bottom_footnotes = true` in the [markdown] section instead. (Available since v0.19.0)
 # Adds backlinks to footnotes (loads ~500 bytes of JavaScripts).


### PR DESCRIPTION
## Summary

This pull request adds an option to the config.toml to change the displayed dates on the bloglist.

### Related issue

#326

## Changes

`config.toml`
```toml
# There are three options to display dates on the bloglist. The bloglist is used on the frontpage and the blog site.
# Use one of the three options.
# Shows the "Last updated on" date
bloglist_date = "updated"
# Shows the creation date
# bloglist_date = "date"
# Shows both dates
# bloglist_date = "both"
```

### Accessibility

<!-- Have you taken steps to make your changes accessible? This could include:
- Semantic HTML
- ARIA attributes
- Keyboard navigation
- Voiceover or screen reader compatibility
- Colour contrast
Please elaborate on the actions taken.
If you need help, please ask! -->

### Screenshots

See the dates on the left side

Option bloglist_date = "updated":

![option updated](https://github.com/welpo/tabi/assets/12381166/2686fc37-18eb-4fa9-9d94-f76ec8574edb)

Option bloglist_date = "date":

![option date](https://github.com/welpo/tabi/assets/12381166/ca7d9d83-8000-408f-a9a7-d9e7589ab6d2)

Option bloglist_date = "both":

![option both](https://github.com/welpo/tabi/assets/12381166/05533936-3126-4f4e-986d-72cb78a756eb)


### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [x] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] Undo demo-setting for `config.toml` (`post_listing_date` should be `"date"`)
- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [x] I have updated `theme.toml` with a sane default for the feature
- [x] I have made corresponding changes to the documentation:
  - [x] Updated `config.toml` comments
  - [x] Updated `theme.toml` comments
  - [x] Updated "Mastering tabi" post in English
  - [x] (Optional) Updated "Mastering tabi" post in Spanish
  - [x] (Optional) Updated "Mastering tabi" post in Catalan
