### PR TITLE
🐛 fix(footer): show feed icon on Zola 0.19.0

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,8 @@ base_url = "https://welpo.github.io/tabi"
 title = "~/tabi"
 description = "tabi is a fast, lightweight, and modern Zola theme with multi-language support, optional JavaScript, and a perfect Lighthouse score."
 author = "welpo"
-generate_feed = true
+generate_feeds = true
+feed_filenames = ["atom.xml"]
 compile_sass = true
 minify_html = true
 build_search_index = true
@@ -50,18 +51,14 @@ skip_anchor_prefixes = [
 [languages.es]
 title = "~/tabi"
 description = "tabi es un tema de Zola rápido, liviano y moderno con JavaScript opcional y una puntuación perfecta en Lighthouse."
-generate_feed = true
-compile_sass = true
-minify_html = true
+generate_feeds = true
 taxonomies = [{name = "tags", feed = true}]
 build_search_index = true
 
 [languages.ca]
 title = "~/tabi"
 description = "tabi és un tema de Zola ràpid, lleuger i modern amb JavaScript opcional i una puntuació perfecta a Lighthouse."
-generate_feed = true
-compile_sass = true
-minify_html = true
+generate_feeds = true
 taxonomies = [{name = "tags", feed = true}]
 
 [extra]

--- a/config.toml
+++ b/config.toml
@@ -2,8 +2,7 @@ base_url = "https://welpo.github.io/tabi"
 title = "~/tabi"
 description = "tabi is a fast, lightweight, and modern Zola theme with multi-language support, optional JavaScript, and a perfect Lighthouse score."
 author = "welpo"
-generate_feeds = true
-feed_filenames = ["atom.xml"]
+generate_feed = true
 compile_sass = true
 minify_html = true
 build_search_index = true
@@ -51,14 +50,14 @@ skip_anchor_prefixes = [
 [languages.es]
 title = "~/tabi"
 description = "tabi es un tema de Zola rápido, liviano y moderno con JavaScript opcional y una puntuación perfecta en Lighthouse."
-generate_feeds = true
+generate_feed = true
 taxonomies = [{name = "tags", feed = true}]
 build_search_index = true
 
 [languages.ca]
 title = "~/tabi"
 description = "tabi és un tema de Zola ràpid, lleuger i modern amb JavaScript opcional i una puntuació perfecta a Lighthouse."
-generate_feeds = true
+generate_feed = true
 taxonomies = [{name = "tags", feed = true}]
 
 [extra]

--- a/config.toml
+++ b/config.toml
@@ -213,6 +213,7 @@ menu = [
 ]
 
 # The RSS icon will be shown if (1) it's enabled and (2) the following variable is set to true.
+# Note for Zola 0.19.X users: when `feed_filenames` has two filenames, only the first one will be linked in the footer.
 feed_icon = true
 
 # Show the full post content in the Atom feed.

--- a/content/_index.ca.md
+++ b/content/_index.ca.md
@@ -1,5 +1,4 @@
 +++
-paginate_path = "/"
 title = "Publicacions recents"
 sort_by = "date"
 template = "section.html"

--- a/content/_index.ca.md
+++ b/content/_index.ca.md
@@ -1,5 +1,5 @@
 +++
-path = "/"
+paginate_path = "/"
 title = "Publicacions recents"
 sort_by = "date"
 template = "section.html"

--- a/content/_index.es.md
+++ b/content/_index.es.md
@@ -1,5 +1,5 @@
 +++
-path = "/"
+paginate_path = "/"
 title = "Publicaciones recientes"
 sort_by = "date"
 template = "section.html"

--- a/content/_index.es.md
+++ b/content/_index.es.md
@@ -1,5 +1,4 @@
 +++
-paginate_path = "/"
 title = "Publicaciones recientes"
 sort_by = "date"
 template = "section.html"

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,4 @@
 +++
-paginate_path = "/"
 title = "Latest posts"
 sort_by = "date"
 template = "section.html"

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,5 @@
 +++
-path = "/"
+paginate_path = "/"
 title = "Latest posts"
 sort_by = "date"
 template = "section.html"

--- a/content/blog/_index.ca.md
+++ b/content/blog/_index.ca.md
@@ -1,6 +1,5 @@
 +++
 paginate_by = 5
-paginate_path = "/blog"
 title = "Blog"
 sort_by = "date"
 template = "section.html"

--- a/content/blog/_index.ca.md
+++ b/content/blog/_index.ca.md
@@ -1,6 +1,6 @@
 +++
 paginate_by = 5
-path = "/blog"
+paginate_path = "/blog"
 title = "Blog"
 sort_by = "date"
 template = "section.html"

--- a/content/blog/_index.es.md
+++ b/content/blog/_index.es.md
@@ -1,6 +1,5 @@
 +++
 paginate_by = 5
-paginate_path = "/blog"
 title = "Blog"
 sort_by = "date"
 template = "section.html"

--- a/content/blog/_index.es.md
+++ b/content/blog/_index.es.md
@@ -1,6 +1,6 @@
 +++
 paginate_by = 5
-path = "/blog"
+paginate_path = "/blog"
 title = "Blog"
 sort_by = "date"
 template = "section.html"

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,6 +1,5 @@
 +++
 paginate_by = 5
-paginate_path = "/blog"
 title = "Blog"
 sort_by = "date"
 template = "section.html"

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,6 +1,6 @@
 +++
 paginate_by = 5
-path = "/blog"
+paginate_path = "/blog"
 title = "Blog"
 sort_by = "date"
 template = "section.html"

--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuració de tabi: guia completa"
 date = 2023-09-18
-updated = 2024-06-19
+updated = 2024-06-22
 description = "Descobreix les múltiples maneres en què pots personalitzar tabi."
 
 [taxonomies]
@@ -653,6 +653,8 @@ Per utilitzar una icona personalitzada, pots afegir-la al directori `static/soci
 |   ❌   |   ❌    |      ✅       |          ❌           |         ❌          |
 
 Pots afegir un enllaç al teu feed RSS/Atom al peu de pàgina amb `feed_icon = true`.
+
+Nota pels usuaris de Zola 0.19.X: quan hi ha dos noms de fitxer a `feed_filenames`, només s'enllaçarà el primer al peu de pàgina.
 
 #### Menú de peu de pàgina
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuración de tabi: guía completa"
 date = 2023-09-18
-updated = 2024-06-19
+updated = 2024-06-22
 description = "Descubre las múltiples maneras en que puedes personalizar tabi."
 
 [taxonomies]
@@ -655,6 +655,8 @@ Para usar un icono personalizado, puedes añadirlo al directorio `static/social_
 |   ❌   |   ❌    |      ✅       |         ❌        |         ❌          |
 
 Puedes añadir un enlace a tu feed RSS/Atom en el pie de página con `feed_icon = true`.
+
+Nota para usuarios de Zola 0.19.X: cuando hay dos nombres de archivo en `feed_filenames`, solo se enlazará el primero en el pie de página.
 
 ### Menú de pie de página
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Mastering tabi Settings: A Comprehensive Guide"
 date = 2023-09-18
-updated = 2024-06-19
+updated = 2024-06-22
 description = "Discover the many ways you can customise your tabi site."
 
 [taxonomies]
@@ -658,6 +658,8 @@ To use a custom icon, you can add it to your site's `static/social_icons` direct
 |  ❌  |   ❌    |      ✅       |         ❌        |         ❌          |
 
 You can add a link to your RSS/Atom feed to the footer with `feed_icon = true`.
+
+Note for Zola 0.19.X users: when there are two filenames in `feed_filenames`, only the first one will be linked in the footer.
 
 ### Footer Menu
 

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -13,9 +13,8 @@
         <nav class="socials nav-navs">
             {%- if config.extra.socials or config.extra.email %}
                 <ul>
-                    {%- if config.generate_feed and config.extra.feed_icon -%}
-                    <li>
-                        <a class="nav-links no-hover-padding social" rel="{{ rel_attributes }}" {{ blank_target }} href={{ get_url(path=config.feed_filename, lang=lang, trailing_slash=false) | safe }}>
+                    {%- if config.feed_filenames and config.feed_filenames | length > 0 -%}
+                        <a class="nav-links no-hover-padding social" rel="{{ rel_attributes }}" {{ blank_target }} href="{{ get_url(path=config.feed_filenames[0], lang=lang, trailing_slash=false) | safe }}">
                         <img alt="feed" title="feed" src="{{ get_url(path='/social_icons/rss.svg') }}">
                         </a>
                     </li>

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -13,8 +13,14 @@
         <nav class="socials nav-navs">
             {%- if config.extra.socials or config.extra.email %}
                 <ul>
-                    {%- if config.feed_filenames and config.feed_filenames | length > 0 -%}
-                        <a class="nav-links no-hover-padding social" rel="{{ rel_attributes }}" {{ blank_target }} href="{{ get_url(path=config.feed_filenames[0], lang=lang, trailing_slash=false) | safe }}">
+                    {# Feed icon #}
+                    {# Zola 0.19.0 uses `generate_feeds`. Prior versions use `generate_feed` #}
+                    {% set generate_feed = config.generate_feeds | default(value=config.generate_feed) %}
+                    {% set feed_url = config.feed_filenames[0] | default(value=(config.feed_filename)) %}
+
+                    {%- if generate_feed and config.extra.feed_icon and feed_url -%}
+                    <li>
+                        <a class="nav-links no-hover-padding social" rel="{{ rel_attributes }}" {{ blank_target }} href={{ get_url(path=feed_url, lang=lang, trailing_slash=false) | safe }}>
                         <img alt="feed" title="feed" src="{{ get_url(path='/social_icons/rss.svg') }}">
                         </a>
                     </li>

--- a/theme.toml
+++ b/theme.toml
@@ -171,6 +171,7 @@ menu = [
 ]
 
 # The RSS icon will be shown if (1) it's enabled and (2) the following variable is set to true.
+# Note for Zola 0.19.X users: when `feed_filenames` has two filenames, only the first one will be linked in the footer.
 feed_icon = true
 
 # Show the full post content in the Atom feed.


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Updates the footer template to work with Zola 0.19.0. Note: if you are using two feeds, only the first one from `feed_filenames` will be linked on the footer.

### Related issue

Fixes #335 

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [X] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [X] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [X] I have made corresponding changes to the documentation:
  - [X] Updated `config.toml` comments
  - [X] Updated `theme.toml` comments
  - [X] Updated "Mastering tabi" post in English
  - [X] (Optional) Updated "Mastering tabi" post in Spanish
  - [X] (Optional) Updated "Mastering tabi" post in Catalan
