### PR TITLE
feat: optional alternative tags sort order based on posts count

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -188,6 +188,11 @@ separator = "•"
 # Compact: tag_name^n (superscript number)
 compact_tags = false
 
+# How tags are sorted in a Tags listing based on templates/tags/list.html.
+# "name" for alphabetical, "frequency" for descending count of posts.
+# Default: "name".
+tag_sorting = "name"
+
 # Invert the order of the site title and page title in the browser tab.
 # Example: true => "Blog • ~/tabi", false => "~/tabi • Blog"
 invert_title_order = false

--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -217,13 +217,22 @@ Aquesta variable accepta qualsevol color CSS vàlid, així que pots utilitzar pa
 |:------:|:------:|:-------------:|:-----------------:|:--------------------:|
 |   ❌   |   ❌   |      ✅       |         ❌        |          ❌          |
 
-Per defecte, la [pàgina d'etiquetes](/tags) mostra les etiquetes com:
+Per defecte, la [pàgina d'etiquetes](/ca/tags) mostra les etiquetes com:
 
 [NomEtiqueta](#) — n entrada[es]
 
 Establir `compact_tags = true` les mostrarà com:
 
 [NomEtiqueta](#) <sup>n</sup>
+
+### Ordre de les etiquetes
+
+| Pàgina | Secció | `config.toml` | Segueix la jerarquia | Requereix JavaScript |
+|:------:|:------:|:-------------:|:-----------------:|:--------------------:|
+|   ❌   |   ❌   |      ✅       |         ❌        |          ❌          |
+
+Per defecte, la [pàgina d'etiquetes](/ca/tags) ordena les etiquetes alfabèticament, donada la configuració predeterminada de `tag_sorting = "name"`.
+Si configures `tag_sorting = "frequency"`, s'ordenaran segons el nombre de publicacions (de més a menys).
 
 ---
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -225,6 +225,15 @@ Establecer `compact_tags = true` mostrará las mismas de este modo:
 
 [NombreEtiqueta](#) <sup>n</sup>
 
+### Orden de las etiquetas
+
+| Página | Sección | `config.toml` | Sigue la jerarquía | Requiere JavaScript |
+|:------:|:-------:|:-------------:|:---------------:|:-------------------:|
+|   ❌   |   ❌    |      ✅       |        ❌        |         ❌          |
+
+Por defecto, la [página de etiquetas](/es/tags) ordena las etiquetas alfabéticamente, dada la configuración predeterminada de `tag_sorting = "name"`.
+Si configuras `tag_sorting = "frequency"`, se ordenarán según el número de publicaciones (de mayor a menor).
+
 ---
 
 ## Integración con repositorios Git

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -225,6 +225,16 @@ Setting `compact_tags = true` will display them as:
 
 [TagName](#) <sup>n</sup>
 
+### Tags Sorting
+
+| Page | Section | `config.toml` | Follows Hierarchy | Requires JavaScript |
+|:----:|:-------:|:-------------:|:-----------------:|:-------------------:|
+|  ❌  |   ❌    |      ✅       |         ❌        |         ❌          |
+
+By default, the [tags page](/tags) sorts tags alphabetically, given the default setting of `tag_sorting = "name"`.
+
+Setting `tag_sorting = "frequency"` will sort them by number-of-posts (descending).
+
 ---
 
 ## Git Repository Integration

--- a/templates/tags/list.html
+++ b/templates/tags/list.html
@@ -7,6 +7,9 @@
 {{ macros_page_header::page_header(title=title)}}
 
 {% set tag_count = terms | length %}
+{% if config.extra.tag_sorting == "frequency" %}
+    {% set terms = terms | sort(attribute="pages") | reverse %}
+{% endif %}
 <div id="tag-cloud" class="{% if tag_count > 16 %}three-columns{% elif tag_count > 8 %}two-columns{% endif %}">
     <ul class="tags">
         {%- for term in terms -%}

--- a/templates/tags/list.html
+++ b/templates/tags/list.html
@@ -9,6 +9,8 @@
 {% set tag_count = terms | length %}
 {% if config.extra.tag_sorting == "frequency" %}
     {% set terms = terms | sort(attribute="pages") | reverse %}
+{% elif config.extra.tag_sorting != "name" %}
+    {{ throw (message="Invalid tag_sorting option: " ~ config.extra.tag_sorting ~ ". Valid options are 'name' and 'frequency'.") }}
 {% endif %}
 <div id="tag-cloud" class="{% if tag_count > 16 %}three-columns{% elif tag_count > 8 %}two-columns{% endif %}">
     <ul class="tags">

--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -7,6 +7,11 @@
 {{ macros_page_header::page_header(title=title)}}
 
 {% set tag_count = terms | length %}
+{% if config.extra.tag_sorting == "frequency" %}
+    {% set terms = terms | sort(attribute="pages") | reverse %}
+{% elif config.extra.tag_sorting != "name" %}
+    {{ throw (message="Invalid tag_sorting option: " ~ config.extra.tag_sorting ~ ". Valid options are 'name' and 'frequency'.") }}
+{% endif %}
 <div id="tag-cloud" class="{% if tag_count > 16 %}three-columns{% elif tag_count > 8 %}two-columns{% endif %}">
     <ul class="tags">
         {%- for term in terms -%}

--- a/theme.toml
+++ b/theme.toml
@@ -146,6 +146,11 @@ separator = "•"
 # Compact: tag_name^n (superscript number)
 compact_tags = false
 
+# How tags are sorted in a Tags listing based on templates/tags/list.html.
+# "name" for alphabetical, "frequency" for descending count of posts.
+# Default: "name".
+tag_sorting = "name"
+
 # Invert the order of the site title and page title in the browser tab.
 # Example: true => "Blog • ~/tabi", false => "~/tabi • Blog"
 invert_title_order = false


### PR DESCRIPTION
## Summary

Adds new variable `tag_sorting` with two options: `name` (default) and `frequency` (new).

### Related issue

Implements feature request: #341 

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [x] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [x] I have updated `theme.toml` with a sane default for the feature
- [x] I have made corresponding changes to the documentation:
  - [x] Updated `config.toml` comments
  - [x] Updated `theme.toml` comments
  - [x] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
