### PR TITLE
Use post.date when no post.updated entry exists

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -148,7 +148,7 @@ show_date = true
 
 # Determines how dates are displayed in the post listing (e.g. front page or /blog). Options:
 # "date" - Show only the original date of the post (default if unset).
-# "updated" - Show only the last updated date of the post.
+# "updated" - Show only the last updated date of the post. If there is no last updated date, it shows the original date.
 # "both" - Show both the original date and the last updated date.
 post_listing_date = "date"
 

--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -146,7 +146,7 @@ El `title` és el títol que apareix a sobre de les publicacions.
 Per defecte, quan es llisten els articles, es mostra la data de creació. Pots configurar quina(es) data(es) mostrar utilitzant l'opció `post_listing_date`. Configuracions disponibles:
 
 - `date`: Mostra només la data de publicació original de l'article (opció per defecte).
-- `updated`: Mostra només la data de l'última actualització de l'article.
+- `updated`: Mostra només la data de l'última actualització de l'article. Si no hi ha data d'actualització, es mostra la data de publicació original.
 - `both`: Mostra tant la data de publicació original com la data de l'última actualització.
 
 #### Llistat de Projectes

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -146,7 +146,7 @@ El `title` es el encabezado que aparece sobre las publicaciones.
 Por defecto, cuando se listan los artículos, se muestra la fecha de creación. Puedes configurar qué fecha(s) mostrar usando la opción `post_listing_date`. Configuraciones disponibles:
 
 - `date`: Muestra solo la fecha de publicación original del artículo (opción por defecto).
-- `updated`: Muestra solo la fecha de la última actualización del artículo.
+- `updated`: Muestra solo la fecha de la última actualización del artículo. Si no hay fecha de actualización, muestra la fecha de publicación original.
 - `both`: Muestra tanto la fecha de publicación original como la fecha de la última actualización.
 
 #### Listado de proyectos

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -146,8 +146,12 @@ The `title` is the header that appears above the posts.
 By default, when listing posts, the date of post creation is shown. You can configure which date(s) to display using the `post_listing_date` option. Available settings:
 
 - `date`: Show only the original date of the post (default).
-- `updated`: Show only the last updated date of the post.
+- `updated`: Show only the last updated date of the post. If there is no last updated date, it shows the original date.
 - `both`: Show both the original date and the last updated date.
+
+```toml
+post_listing_date = "date"
+```
 
 #### Listing Projects
 

--- a/templates/macros/list_posts.html
+++ b/templates/macros/list_posts.html
@@ -20,7 +20,7 @@
                     {{ throw(message="ERROR: Invalid value for config.extra.post_listing_date. Allowed values are 'date', 'updated', or 'both'.") }}
                 {%- endif -%}
 
-                {%- set show_date = post.date and post_listing_date == "date" or post.date and post_listing_date == "both" -%}
+                {%- set show_date = post.date and post_listing_date == "date" or post.date and post_listing_date == "both" or post.date and post_listing_date == "updated" and not post.updated -%}
                 {%- set show_updated = post.updated and post_listing_date == "updated" or post.updated and post_listing_date == "both" -%}
 
                 {%- if show_date or show_updated -%}

--- a/theme.toml
+++ b/theme.toml
@@ -105,7 +105,7 @@ show_date = true
 
 # Determines how dates are displayed in the post listing (e.g. front page or /blog). Options:
 # "date" - Show only the original date of the post (default if unset).
-# "updated" - Show only the last updated date of the post.
+# "updated" - Show only the last updated date of the post. If there is no last updated date, it shows the original date.
 # "both" - Show both the original date and the last updated date.
 post_listing_date = "date"
 


### PR DESCRIPTION
## Summary


Without this fix, there is no date if you set `post_listing_date = "updated"` and the post has no updated date.

![image](https://github.com/user-attachments/assets/3a6c7f5b-c192-4878-b73b-f3d1be4a5d7a)


### Related issue

#326 

#330 


## Changes

If the post doesn't has an updated entry, the creation date is used:

![image](https://github.com/user-attachments/assets/ea66d6b6-11f5-4198-b5d0-4bf1d7d5678c)



### Accessibility

<!-- Have you taken steps to make your changes accessible? This could include:
- Semantic HTML
- ARIA attributes
- Keyboard navigation
- Voiceover or screen reader compatibility
- Colour contrast
Please elaborate on the actions taken.
If you need help, please ask! -->

### Screenshots

<!-- If applicable, add screenshots to help explain the changes made. Consider if a before/after is helpful -->

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [x] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [ ] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [x] I have made corresponding changes to the documentation:
  - [x] Updated `config.toml` comments
  - [x] Updated `theme.toml` comments
  - [x] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
