### PR TITLE
🐛 fix(header): render feed links based on config

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -14,9 +14,25 @@
         <link rel=icon href='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 105 55"><text y=".7em" font-size="82">{{ config.extra.favicon_emoji }}</text></svg>'>
     {% endif %}
 
-    {# Feed #}
-    <link rel="alternate" type="application/atom+xml" title="{{ config.title | safe }}" href="{{ get_url(path="atom.xml",
-        trailing_slash=false) }}">
+    {# Feeds #}
+    {% if config.generate_feeds | default(value=config.generate_feed) %}
+        {% if config.feed_filenames %}
+            {# Zola 0.19 and newer #}
+            {% for feed in config.feed_filenames %}
+                {% if feed == "atom.xml" %}
+                    <link rel="alternate" type="application/atom+xml" title="{{ config.title | safe }} - Atom Feed" href="{{ get_url(path=feed, trailing_slash=false) | safe }}">
+                {% elif feed == "rss.xml" %}
+                    <link rel="alternate" type="application/rss+xml" title="{{ config.title | safe }} - RSS Feed" href="{{ get_url(path=feed, trailing_slash=false) | safe }}">
+                {% else %}
+                    <link rel="alternate" href="{{ get_url(path=feed, trailing_slash=false) | safe }}">
+                {% endif %}
+            {% endfor %}
+        {% else %}
+            {# Older Zola versions #}
+            {% set feed_url = config.feed_filename | default(value="atom.xml") %}
+            <link rel="alternate" type="application/atom+xml" title="{{ config.title | safe }}" href="{{ get_url(path=feed_url, trailing_slash=false) | safe }}">
+        {% endif %}
+    {% endif %}
 
     {# CSS #}
     {# Load subset of glyphs for header. Avoids flashing issue in Firefox #}


### PR DESCRIPTION
## Summary

This PR fixes a bug where feed links were being rendered in the header even when feeds were disabled. It introduces a more flexible and robust solution for handling feed links in the header template.

### Related issue

Fixes #352.

## Changes

- Modified `header.html` to conditionally render feed links
- Added support for multiple feed types (Atom and RSS)
- Improved code to use `config.feed_filenames` for Zola 0.19.x and newer, falling back to `config.feed_filename` for older versions

### Accessibility

Unaffected.

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [x] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan