### PR TITLE
💄 style(error): enhance visibility of Zola errors

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -21,6 +21,7 @@
 @use 'parts/_table.scss';
 @use 'parts/_tags.scss';
 @use 'parts/_theme-switch.scss';
+@use 'parts/_zola-error.scss';
 
 @font-face {
     src: local('Inter'),

--- a/sass/parts/_zola-error.scss
+++ b/sass/parts/_zola-error.scss
@@ -1,5 +1,5 @@
 // Styles Zola error messages. See https://github.com/welpo/tabi/pull/359
-body > div:last-child > div:last-child {
+body > div:last-child > div:last-child[style]:not([class]):not([id]) {
     position: fixed;
     top: 50%;
     left: 50%;
@@ -14,13 +14,13 @@ body > div:last-child > div:last-child {
     max-width: 80%;
 }
 
-body > div:last-child > div:last-child p {
+body > div:last-child > div:last-child[style]:not([class]):not([id]) > p[style]:first-child {
     margin: 0;
     color: var(--admonition-danger-border);
     font-weight: bold;
 }
 
-body > div:last-child > div:last-child pre {
+body > div:last-child > div:last-child[style]:not([class]):not([id]) > pre[style]:last-child {
     margin-bottom: 0;
     background-color: var(--admonition-danger-code);
     padding: 10px;

--- a/sass/parts/_zola-error.scss
+++ b/sass/parts/_zola-error.scss
@@ -1,0 +1,28 @@
+// Styles Zola error messages. See https://github.com/welpo/tabi/pull/359
+body > div:last-child > div:last-child {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 9999;
+    box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px;
+    border: 2px solid var(--admonition-danger-border);
+    border-radius: 5px;
+    background-color: var(--admonition-danger-bg);
+    padding: 15px;
+    width: fit-content;
+    max-width: 80%;
+}
+
+body > div:last-child > div:last-child p {
+    margin: 0;
+    color: var(--admonition-danger-border);
+    font-weight: bold;
+}
+
+body > div:last-child > div:last-child pre {
+    margin-bottom: 0;
+    background-color: var(--admonition-danger-code);
+    padding: 10px;
+    overflow-x: auto;
+}


### PR DESCRIPTION
## Summary

This PR introduces minimal CSS styling to enhance the visibility of Zola error messages during development. It centers the error messages both vertically and horizontally on the screen and applies consistent styling using theme variables.

CSS specificity should target only Zola errors and not affect user content.

## Changes

- Added a new SCSS file `zola-error.scss` to style Zola error messages
- Positioned error messages in the center of the viewport
- Applied theme-consistent colors using existing CSS variables
- Improved readability of error messages

### Accessibility

The changes improve the visibility of error messages, which enhances the overall accessibility of the development process. The centered position and improved contrast make the messages easier to notice and read for all users.

### Screenshots

#### Before

Hard to see, at the very bottom of the page, below the footer:

![before](https://github.com/user-attachments/assets/2302ed8b-a6e0-42a2-8e9a-80e75c47c81a)

#### After

Floating, centered:

![after](https://github.com/user-attachments/assets/e41dc7bf-b220-477e-b8aa-17a776d9f576)

### Type of change

- [ ] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [x] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan