### PR TITLE
Add missing quotes around some expressions

### DIFF
--- a/templates/macros/list_posts.html
+++ b/templates/macros/list_posts.html
@@ -62,7 +62,7 @@
                         <p>{{ post.summary | striptags | trim_end_matches(pat=".") | safe }}…</p>
                     {% endif %}
                 </div>
-                <a class="readmore" href={{ post.permalink }}>{{ macros_translate::translate(key="read_more", default="Read more", language_strings=language_strings) }}&nbsp;<span class="arrow">→</span></a>
+                <a class="readmore" href="{{ post.permalink }}">{{ macros_translate::translate(key="read_more", default="Read more", language_strings=language_strings) }}&nbsp;<span class="arrow">→</span></a>
             </div>
         </section>
     {% endif %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -110,7 +110,7 @@
             {%- if page.taxonomies and page.taxonomies.tags -%}
                 {%- if previous_visible -%}&nbsp;{{ separator }}&nbsp;{%- endif -%}<li>{{- macros_translate::translate(key="tags", default="tags", language_strings=language_strings) | capitalize -}}:&nbsp;</li>
                 {%- for tag in page.taxonomies.tags -%}
-                    <li><a href={{ get_taxonomy_url(kind='tags', name=tag, lang=lang) | safe }}>{{ tag }}</a>
+                    <li><a href="{{ get_taxonomy_url(kind='tags', name=tag, lang=lang) | safe }}">{{ tag }}</a>
                     {%- if not loop.last -%}
                         ,&nbsp;
                     {%- endif -%}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -20,7 +20,7 @@
 
                     {%- if generate_feed and config.extra.feed_icon and feed_url -%}
                     <li>
-                        <a class="nav-links no-hover-padding social" rel="{{ rel_attributes }}" {{ blank_target }} href={{ get_url(path=feed_url, lang=lang, trailing_slash=false) | safe }}>
+                        <a class="nav-links no-hover-padding social" rel="{{ rel_attributes }}" {{ blank_target }} href="{{ get_url(path=feed_url, lang=lang, trailing_slash=false) | safe }}">
                         <img alt="feed" title="feed" src="{{ get_url(path='/social_icons/rss.svg') }}">
                         </a>
                     </li>
@@ -56,8 +56,8 @@
                     {%- if config.extra.socials %}
                         {% for social in config.extra.socials %}
                             <li>
-                                <a class="nav-links no-hover-padding social" rel="{{ rel_attributes }} me" {{ blank_target }} href={{ social.url | safe }}>
-                                    <img alt={{ social.name }} title={{ social.name }} src="{{ get_url(path='social_icons/' ~ social.icon ~ '.svg') }}">
+                                <a class="nav-links no-hover-padding social" rel="{{ rel_attributes }} me" {{ blank_target }} href="{{ social.url | safe }}">
+                                    <img alt="{{ social.name }}" title="{{ social.name }}" src="{{ get_url(path='social_icons/' ~ social.icon ~ '.svg') }}">
                                 </a>
                             </li>
                         {% endfor %}

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -1,7 +1,7 @@
 <header>
     <nav class="navbar">
         <div class="nav-title">
-            <a class="home-title" href={{ get_url(path="/", lang=lang) }}>{{ config.title }}</a>
+            <a class="home-title" href="{{ get_url(path='/', lang=lang) }}">{{ config.title }}</a>
         </div>
 
         {%- if config.extra.menu %}


### PR DESCRIPTION
## Summary

Adds quotes around expressions in places where they were missing.

## Changes

Mostly fixed `href` attributes of links, errors which are ignored by web browsers. Also fixed `alt` and `title` attributes of links inside the social navigation block.

### Accessibility

This was my initial motivation for doing this, as missing quotes around `alt` and `title` attributes on links inside the social navigation block prevents putting text with spaces.

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [x] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [ ] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
