### PR TITLE
🐛 fix(rtl): fix blockquote in rtl

### DIFF
--- a/sass/parts/_misc.scss
+++ b/sass/parts/_misc.scss
@@ -62,8 +62,8 @@ ul {
 
 blockquote {
     margin: 0;
-    border-left: 0.3rem solid var(--primary-color);
-    padding-left: 1em;
+    border-inline-start: 0.3rem solid var(--primary-color);
+    padding-inline-start: 1em;
 }
 
 a {


### PR DESCRIPTION
## Changes

New blockquote for RTL, where the border and padding in the right

### Note
I have tried `:dir(rtl)` syntax but it doesn't work properly, also I tried to use `[dir="rtl"]` only without ltr, but it doesn't work

### Screenshots

| Before | After |
| :----: | :---: |
| ![image](https://github.com/user-attachments/assets/8b52e44b-b892-4999-a647-08d5cb820b72)  | ![image](https://github.com/user-attachments/assets/97f23fa1-14d9-455d-b451-d3570b46e4a3) |

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [X] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [X] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [X] I have verified the accessibility of my changes
- [X] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
