### PR TITLE
♿️ fix: reduce main page header/list sizes

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -220,7 +220,7 @@ h1 {
     margin-bottom: 0em;
     margin-left: 0;
     font-weight: 550;
-    font-size: 1.62em;
+    font-size: 1.62rem;
 }
 
 h2 {
@@ -230,7 +230,7 @@ h2 {
     margin-bottom: 0em;
     margin-left: 0;
     font-weight: 550;
-    font-size: 1.4em;
+    font-size: 1.4rem;
 }
 
 h3 {
@@ -240,7 +240,7 @@ h3 {
     margin-bottom: 0em;
     margin-left: 0;
     font-weight: 550;
-    font-size: 1.2em;
+    font-size: 1.2rem;
 }
 
 h4 {
@@ -250,7 +250,7 @@ h4 {
     margin-bottom: 0em;
     margin-left: 0;
     font-weight: 550;
-    font-size: 1em;
+    font-size: 1rem;
 }
 
 h5 {
@@ -260,7 +260,7 @@ h5 {
     margin-bottom: 0em;
     margin-left: 0;
     font-weight: normal;
-    font-size: 1em;
+    font-size: 1rem;
 }
 
 p {

--- a/sass/parts/_home-banner.scss
+++ b/sass/parts/_home-banner.scss
@@ -16,6 +16,10 @@
         font-size: 1.875rem;
         line-height: 3rem;
 
+        li {
+            font-size: 1rem;
+        }
+
         #home-banner-header {
             margin: 0;
             margin-bottom: 1rem;


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Reduces the sizes of headers and lists on the main page to align with the sizing of single pages. This avoids overlapping text and too-large lists on the main landing page.

### Related issue

Resolves #374.

## Changes

- Sets `rem` sizes for headers instead of `em`
- Sets a size of `1rem` for lists in the home banner.

### Accessibility

Improved by avoding overlapping header text as well as properly sized list elements.

### Screenshots

Before, on small screens or large text setups the header text would overlap when wrapped:

![old](https://github.com/user-attachments/assets/334ff378-bfeb-42a3-85c2-7fa4a8faaeae)

Now, headers and lists have the same size as they would in articles, avoiding overlapping text and too-large lists:

![new](https://github.com/user-attachments/assets/5338a0b6-738c-4381-9e71-fbd651dc0361)

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [X] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [X] I have verified the accessibility of my changes
- [ ] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
