### PR TITLE
🐛 fix: allow pages within pages

### DIFF
--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuració de tabi: guia completa"
 date = 2023-09-18
-updated = 2024-08-28
+updated = 2024-09-17
 description = "Descobreix les múltiples maneres en què pots personalitzar tabi."
 
 [taxonomies]
@@ -25,11 +25,12 @@ tabi té una jerarquia que permet personalitzar el teu lloc a diferents nivells.
 
 1. **Configuracions globals**: Aquestes són les configuracions que s'apliquen a tot el teu lloc. Es configuren a `config.toml`.
 2. **Configuracions de secció**: Aquestes són les configuracions que s'apliquen a una secció del teu lloc (per exemple, `/blog` o `/projects`). Es configuren a la metainformació de l'arxiu `_index.md` de la secció.
-3. **Configuracions de pàgina**: Aquestes són les configuracions que s'apliquen a una sola pàgina. Es configuren a la metainformació de la pàgina.
+3. **Configuració de la pàgina «pare»**: Per a pàgines anidades (pàgines dins de pàgines), aquestes són les configuracions de la pàgina que les conté.
+4. **Configuracions de pàgina**: Aquestes són les configuracions que s'apliquen a una sola pàgina. Es configuren a la metainformació de la pàgina.
 
 En tots els casos, les opcions de tabi es configuren a la secció `[extra]`.
 
-Per a les configuracions que segueixen aquesta jerarquia, el valor establert a una pàgina reemplaça el valor d'una secció, que al seu torn reemplaça el valor global. En resum: com més específica sigui la configuració, més prioritat tindrà, o `pàgina > secció > config.toml`.
+Per a les configuracions que segueixen aquesta jerarquia, el valor establert a una pàgina reemplaça el valor d'una secció, que al seu torn reemplaça el valor global. En resum: com més específica sigui la configuració, més prioritat tindrà, o `pàgina > pàgina pare/secció > config.toml`.
 
 ---
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuración de tabi: guía completa"
 date = 2023-09-18
-updated = 2024-08-28
+updated = 2024-09-17
 description = "Descubre las múltiples maneras en que puedes personalizar tabi."
 
 [taxonomies]
@@ -25,11 +25,12 @@ tabi tiene una jerarquía que te permite personalizar tu sitio en diferentes niv
 
 1. **Configuraciones globales**: Estas son las configuraciones que se aplican a todo tu sitio. Se establecen en `config.toml`.
 2. **Configuraciones de sección**: Estas son las configuraciones que se aplican a una sección de tu sitio (por ejemplo, `/blog` o `/projects`). Se establecen en la metainformación del archivo `_index.md` de la sección.
-3. **Configuraciones de página**: Estas son las configuraciones que se aplican a una sola página. Se establecen en la metainformación de la página.
+3. **Configuración de la página «padre»**: Para páginas anidadas (páginas dentro de páginas), estas son las configuraciones de la página que las contiene.
+4. **Configuraciones de página**: Estas son las configuraciones que se aplican a una sola página. Se establecen en la metainformación de la página.
 
 En todos los casos, las opciones de tabi se establecen en la sección `[extra]`.
 
-Para las configuraciones que siguen esta jerarquía, el valor establecido en una página reemplaza el valor de una sección, que a su vez reemplaza el valor global. En resumen: cuanto más específica sea la configuración, mayor prioridad tendrá, o `página > sección > config.toml`.
+Para las configuraciones que siguen esta jerarquía, el valor establecido en una página reemplaza el valor de una sección, que a su vez reemplaza el valor global. En resumen: cuanto más específica sea la configuración, mayor prioridad tendrá, o `página > página padre/sección > config.toml`.
 
 ---
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Mastering tabi Settings: A Comprehensive Guide"
 date = 2023-09-18
-updated = 2024-08-28
+updated = 2024-09-17
 description = "Discover the many ways you can customise your tabi site."
 
 [taxonomies]
@@ -25,11 +25,12 @@ tabi has a hierarchy that allows you to customise your site at different levels.
 
 1. **Global settings**: These are the settings that apply to your entire site. They are set in `config.toml`.
 2. **Section settings**: These are the settings that apply to a section of your site (e.g.`/blog` or `/projects`). They are set in the front matter of the `_index.md` file of the section.
-3. **Page settings**: These are the settings that apply to a single page. They are set in the front matter of the page.
+3. **Parent page settings**: For nested pages (pages within pages), these are the settings from the parent page.
+4. **Page settings**: These are the settings that apply to a single page. They are set in the front matter of the page.
 
 In all cases, tabi's settings are set in the `[extra]` section.
 
-For settings which follow this hierarchy, the value set on a page overrides the value for a section, which overrides the global value. In short: the more specific the setting, the higher priority it has, or `page > section > config.toml`.
+For settings which follow this hierarchy, the value set on a page overrides the value for a section, which overrides the global value. In short: the more specific the setting, the higher priority it has, or `page > parent page/section > config.toml`.
 
 ---
 

--- a/templates/macros/settings.html
+++ b/templates/macros/settings.html
@@ -14,9 +14,38 @@ Parameters:
 {%- if section -%}
     {%- set current_section = section -%}
 {%- elif page -%}
+    {%- set current_section = "" -%}
     {#- Retrieve last ancestor to determine current section, if applicable -#}
-    {%- set last_ancestor = page.ancestors | slice(start=-1) %}
-    {%- set current_section = get_section(path=last_ancestor.0, metadata_only=true) %}
+    {%- if page.ancestors | length > 0 -%}
+        {%- set last_ancestor = page.ancestors | slice(start=-1) -%}
+        {%- set_global current_section = get_section(path=last_ancestor.0, metadata_only=true) -%}
+    {%- else -%}
+        {#- We're likely in a nested page. Try to find the parent page or nearest section. -#}
+        {%- set components = page.components -%}
+        {%- for i in range(start=1, end=components | length) -%}
+            {%- if lang == config.default_language -%}
+                {%- set potential_path = components | slice(end=components | length - i) | join(sep="/") -%}
+                {%- set potential_page = potential_path ~ "/index.md" -%}
+                {%- set potential_section = potential_path ~ "/_index.md" -%}
+            {%- else -%}
+                {%- set potential_path = components | slice(start=1, end=components | length - i) | join(sep="/") -%}
+                {%- set potential_page = potential_path ~ "/index." ~ lang ~ ".md" -%}
+                {%- set potential_section = potential_path ~ "/_index." ~ lang ~ ".md" -%}
+            {%- endif -%}
+            {#- Check for parent page first. -#}
+            {%- set page_data = load_data(path=potential_page, required=false) -%}
+            {%- if page_data -%}
+                {%- set_global current_section = get_page(path=potential_page) -%}
+                {%- break -%}
+            {%- endif -%}
+            {#- No parent page, check for section. -#}
+            {%- set section_data = load_data(path=potential_section, required=false) -%}
+            {%- if section_data -%}
+                {%- set_global current_section = get_section(path=potential_section, metadata_only=true) -%}
+                {%- break -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
 {%- endif -%}
 
 {%- set priority_order = [

--- a/templates/page.html
+++ b/templates/page.html
@@ -12,48 +12,94 @@
 {%- endif -%}
 
 {# Debugging #}
-{# {% set last_ancestor = page.ancestors | slice(start=-1) %}
-{% set current_section = get_section(path=last_ancestor.0) %}
+{# <div><pre>
+    Page path: {{ page.path }}
+    Page components: {{ page.components | join(sep=", ") }}
+    Page ancestors: {{ page.ancestors | join(sep=", ") }}
+    Current language: {{ lang }}
+    Default language: {{ config.default_language }}
+    Current section: {% if current_section %}{{ current_section.path }}{% else %}None{% endif %}
+    Page extra: {{ page.extra | json_encode() }}
+    {% if section -%}
+        {%- set current_section = section -%}
+    {%- elif page -%}
+        {%- set current_section = "" -%}
+        {%- if page.ancestors | length > 0 -%}
+            {%- set last_ancestor = page.ancestors | slice(start=-1) -%}
+            {%- set_global current_section = get_section(path=last_ancestor.0, metadata_only=true) -%}
+        {%- else -%}
+            {%- set components = page.components -%}
+            {%- for i in range(start=1, end=components | length) -%}
+                {%- if lang == config.default_language -%}
+                    {%- set potential_path = components | slice(end=components | length - i) | join(sep="/") -%}
+                    {%- set potential_page = potential_path ~ "/index.md" -%}
+                    {%- set potential_section = potential_path ~ "/_index.md" -%}
+                {%- else -%}
+                    {%- set potential_path = components | slice(start=1, end=components | length - i) | join(sep="/") -%}
+                    {%- set potential_page = potential_path ~ "/index." ~ lang ~ ".md" -%}
+                    {%- set potential_section = potential_path ~ "/_index." ~ lang ~ ".md" -%}
+                {%- endif -%}
+                Checking parent page: {{ potential_page }}
+                {%- set page_data = load_data(path=potential_page, required=false) -%}
+                {%- if page_data -%}
+                    {%- set_global current_section = get_page(path=potential_page) %}
+    Parent page found: {{ current_section.path }}
+                    {%- break -%}
+                {%- endif -%}
+                Checking section: {{ potential_section }}
+                {%- set section_data = load_data(path=potential_section, required=false) -%}
+                {%- if section_data -%}
+                    {%- set_global current_section = get_section(path=potential_section, metadata_only=true) -%}
+                    Section found: {{ current_section.path }}
+                    {%- break -%}
+                {%- endif -%}
+            {%- endfor -%}
+        {%- endif -%}
+    {%- endif %}
+Found nearest parent/section: {% if current_section %}{{ current_section.path }}{% else %}None{% endif %}
+Current section extra: {% if current_section %}{{ current_section.extra | json_encode() }}{% else %}None{% endif %}
+</pre></div>
 
-{% set settings_to_test = [
-    "footnote_backlinks",
-    "add_src_to_code_block",
-    "copy_button",
-    "katex",
-    "quick_navigation_buttons",
-    "show_reading_time",
-    "show_date",
-    "show_author",
-    "show_remote_changes",
-    "toc",
-    "show_previous_next_article_links",
-    "invert_previous_next_article_links",
-    "previous_next_article_links_full_width",
-    "enable_csp",
-] %}
+    {% set settings_to_test = [
+        "footnote_backlinks",
+        "add_src_to_code_block",
+        "copy_button",
+        "katex",
+        "quick_navigation_buttons",
+        "show_reading_time",
+        "show_date",
+        "show_author",
+        "show_remote_changes",
+        "toc",
+        "show_previous_next_article_links",
+        "invert_previous_next_article_links",
+        "previous_next_article_links_full_width",
+        "enable_csp",
+    ] %}
 
-<table>
-    <thead>
-        <tr>
-            <th>setting</th>
-            <th>page</th>
-            <th>section</th>
-            <th>config</th>
-            <th>macro output</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for setting in settings_to_test %}
+    <table>
+        <thead>
             <tr>
-                <td><code>{{ setting }}</code></td>
-                <td>{{ page.extra[setting] | default(value="⬛") }}</td>
-                <td>{{ current_section.extra[setting] | default(value="⬛") }}</td>
-                <td>{{ config.extra[setting] | default(value="⬛") }}</td>
-                <td>{{ macros_settings::evaluate_setting_priority(setting=setting, page=page) }}</td>
+                <th>setting</th>
+                <th>page</th>
+                <th>section</th>
+                <th>config</th>
+                <th>macro output</th>
             </tr>
-        {% endfor %}
-    </tbody>
-</table> #}
+        </thead>
+        <tbody>
+            {% for setting in settings_to_test %}
+                <tr>
+                    <td><code>{{ setting }}</code></td>
+                    <td>{{ page.extra[setting] | default(value="⬛") }}</td>
+                    <td>{{ current_section.extra[setting] | default(value="⬛") }}</td>
+                    <td>{{ config.extra[setting] | default(value="⬛") }}</td>
+                    <td>{{ macros_settings::evaluate_setting_priority(setting=setting, page=page) }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div> #}
 {# {{ __tera_context }} #}
 {# End debugging #}
 


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Fixes the build error for pages nested within pages and implements a new hierarchy system to find the nearest parent page or section for nested pages.

### Related issue

Fixes #384.

## Changes

- Fix build error for pages nested within pages by checking for `last_ancestors` length
- When a page is within a page, the hierarchy would not find the nearest section. This PR implements the logic to find the parent page or nearest section based on the `page.components`. It uses a hack to check if a file (section) exists and manually builds the path to the `_index.md`. In short: it's fragile. It was either this or have the hierarchy not work for nested pages.
- Update docs regarding Hierarchy to mention nested pages behaviour
- Add comprehensive debugging output for future troubleshooting

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [X] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [X] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [X] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [X] Updated "Mastering tabi" post in English
  - [X] (Optional) Updated "Mastering tabi" post in Spanish
  - [X] (Optional) Updated "Mastering tabi" post in Catalan
