### PR TITLE
🐛 fix(feed): resolve Atom feed validation issues

### DIFF
--- a/static/feed_style.xsl
+++ b/static/feed_style.xsl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  xmlns:atom="http://www.w3.org/2005/Atom" xmlns:base="http://purl.org/atompub/base/1.0/" xmlns:str="https://github.com/welpo/tabi">
+  xmlns:atom="http://www.w3.org/2005/Atom" xmlns:tabi="https://github.com/welpo/tabi">
   <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
   <xsl:template match="/">
     <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
       <xsl:attribute name="data-theme">
-        <xsl:value-of select="/atom:feed/str:translations/str:default_theme"/>
+        <xsl:value-of select="/atom:feed/tabi:metadata/tabi:default_theme"/>
       </xsl:attribute>
       <head>
         <title>
@@ -24,13 +24,13 @@
             <div class="info-box">
               <!-- This block replaces the text "About Feeds" with a hyperlink in the translated string -->
               <xsl:choose>
-                <xsl:when test="contains(/atom:feed/str:translations/str:about_feeds, 'About Feeds')">
-                  <xsl:value-of select="substring-before(/atom:feed/str:translations/str:about_feeds, 'About Feeds')"/>
+                <xsl:when test="contains(/atom:feed/tabi:metadata/tabi:about_feeds, 'About Feeds')">
+                  <xsl:value-of select="substring-before(/atom:feed/tabi:metadata/tabi:about_feeds, 'About Feeds')"/>
                   <a href="https://aboutfeeds.com/" target="_blank">About Feeds</a>
-                  <xsl:value-of select="substring-after(/atom:feed/str:translations/str:about_feeds, 'About Feeds')"/>
+                  <xsl:value-of select="substring-after(/atom:feed/tabi:metadata/tabi:about_feeds, 'About Feeds')"/>
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:value-of select="/atom:feed/str:translations/str:about_feeds"/>
+                  <xsl:value-of select="/atom:feed/tabi:metadata/tabi:about_feeds"/>
                 </xsl:otherwise>
               </xsl:choose>
             </div>
@@ -45,14 +45,14 @@
                 <xsl:attribute name="href">
                   <xsl:value-of select="/atom:feed/@xml:base"/>
                 </xsl:attribute>
-                <xsl:value-of select="/atom:feed/str:translations/str:visit_the_site" />&#160;<span class="arrow">→</span>
+                <xsl:value-of select="/atom:feed/tabi:metadata/tabi:visit_the_site" />&#160;<span class="arrow">→</span>
               </a>
               <p></p>
             </section>
             <div class="padding-top listing-title bottom-divider">
-              <h1><xsl:value-of select="/atom:feed/str:translations/str:recent_posts" /></h1>
+              <h1><xsl:value-of select="/atom:feed/tabi:metadata/tabi:recent_posts" /></h1>
             </div>
-            <xsl:variable name="post_listing_date" select="/atom:feed/atom:post_listing_date"/>
+            <xsl:variable name="post_listing_date" select="/atom:feed/tabi:metadata/tabi:post_listing_date"/>
             <div class="bloglist-container">
               <xsl:for-each select="/atom:feed/atom:entry">
                 <section class="bloglist-row bottom-divider">
@@ -68,13 +68,13 @@
 
                     <xsl:if test="$show_date and $show_updated">
                       <li class="mobile-only">
-                        <xsl:value-of select="/atom:feed/str:translations/str:separator"/>
+                        <xsl:value-of select="/atom:feed/tabi:metadata/tabi:separator"/>
                       </li>
                     </xsl:if>
 
                     <xsl:if test="$show_updated">
                       <li class="date">
-                        <xsl:variable name="update_string" select="/atom:feed/str:translations/str:last_updated_on"/>
+                        <xsl:variable name="update_string" select="/atom:feed/tabi:metadata/tabi:last_updated_on"/>
                         <xsl:variable name="update_date" select="substring(atom:updated, 0, 11)"/>
                         <xsl:value-of select="substring-before($update_string, '$DATE')"/>
                         <xsl:value-of select="$update_date"/>

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -7,27 +7,30 @@
 {%- endif -%}
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="{{ get_url(path='/feed_style.xsl', trailing_slash=false) | safe }}" type="text/xsl"?>
-<feed xmlns="http://www.w3.org/2005/Atom" xmlns:base="http://purl.org/atompub/base/1.0/" xml:lang="{{ lang }}" xml:base="{{ config.base_url }}">
-    <str:translations xmlns:str="https://github.com/welpo/tabi">
-        <str:separator>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ lang }}" xml:base="{{ config.base_url }}">
+    <tabi:metadata xmlns:tabi="https://github.com/welpo/tabi">
+        <tabi:separator>
             {{  config.extra.separator | default(value="•") }}
-        </str:separator>
-        <str:about_feeds>
+        </tabi:separator>
+        <tabi:about_feeds>
             {{- macros_translate::translate(key="about_feeds", default="This is a web feed, also known as an Atom feed. Subscribe by copying the URL from the address bar into your newsreader", language_strings=language_strings) -}}
-        </str:about_feeds>
-        <str:visit_the_site>
+        </tabi:about_feeds>
+        <tabi:visit_the_site>
             {{- macros_translate::translate(key="visit_the_site", default="Visit website", language_strings=language_strings) -}}
-        </str:visit_the_site>
-        <str:recent_posts>
+        </tabi:visit_the_site>
+        <tabi:recent_posts>
             {{- macros_translate::translate(key="recent_posts", default="Recent posts", language_strings=language_strings) -}}
-        </str:recent_posts>
-        <str:last_updated_on>
+        </tabi:recent_posts>
+        <tabi:last_updated_on>
             {{- macros_translate::translate(key="last_updated_on", default="Updated on $DATE", language_strings=language_strings) -}}
-        </str:last_updated_on>
-        <str:default_theme>
+        </tabi:last_updated_on>
+        <tabi:default_theme>
             {{- config.extra.default_theme | default(value="") -}}
-        </str:default_theme>
-    </str:translations>
+        </tabi:default_theme>
+        <tabi:post_listing_date>
+            {{- config.extra.post_listing_date | default(value="date") -}}
+        </tabi:post_listing_date>
+    </tabi:metadata>
 
     {#- Load extra CSS (skin) if set in config.toml -#}
     {%- if config.extra.skin -%}
@@ -43,14 +46,13 @@
         <subtitle>{{ config.description }}</subtitle>
     {%- endif %}
     <link href="{{ feed_url | safe }}" rel="self" type="application/atom+xml"/>
-    <post_listing_date>{{ config.extra.post_listing_date | default(value="date") }}</post_listing_date>
     <link href="
         {%- if section -%}
             {{ section.permalink | escape_xml | safe }}
         {%- else -%}
             {{ get_url(path="/", lang=lang) | escape_xml | safe }}
         {%- endif -%}
-    "/>
+    " rel="alternate" type="text/html"/>
     <generator uri="https://www.getzola.org/">Zola</generator>
     <updated>{{ last_updated | date(format="%+") }}</updated>
     <id>{{ feed_url | safe }}</id>


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Addresses W3C validation warnings for the Atom feed and improves compliance with feed standards. It restructures the custom metadata in the feed and adjusts the XSL transformation accordingly.

### Related issue

Reported in #391.

## Changes

- Remove custom `post_listing_date` element from main feed structure
- Remove unused `xmlns:base` attribute from `<feed>` element
- Replace `str` namespace with `tabi` and move custom elements to `<tabi:metadata>`
- Add `rel="alternate"` to main site link for clarity
- Adjust XSL transformation to match new feed structure

### Accessibility

Probably unchanged. Possibly improved due to better compatibility with feed readers.

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [X] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [ ] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
