### PR TITLE
✨ feat(feed): make "Visit website" link context-aware

### DIFF
--- a/static/feed_style.xsl
+++ b/static/feed_style.xsl
@@ -43,9 +43,14 @@
               </p>
               <a class="readmore">
                 <xsl:attribute name="href">
-                  <xsl:value-of select="/atom:feed/@xml:base"/>
+                  <xsl:value-of select="/atom:feed/atom:link[@rel='alternate']/@href"/>
                 </xsl:attribute>
-                <xsl:value-of select="/atom:feed/tabi:metadata/tabi:visit_the_site" />&#160;<span class="arrow">→</span>
+                <xsl:value-of select="/atom:feed/tabi:metadata/tabi:visit_the_site" />
+                <xsl:if test="/atom:feed/tabi:metadata/tabi:current_section != /atom:feed/atom:title">
+                  <xsl:text>: </xsl:text>
+                  <xsl:value-of select="/atom:feed/tabi:metadata/tabi:current_section" />
+                </xsl:if>
+                <span class="arrow"> →</span>
               </a>
               <p></p>
             </section>

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -7,7 +7,7 @@
 {%- endif -%}
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="{{ get_url(path='/feed_style.xsl', trailing_slash=false) | safe }}" type="text/xsl"?>
-<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ lang }}" xml:base="{{ config.base_url }}">
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ lang }}">
     <tabi:metadata xmlns:tabi="https://github.com/welpo/tabi">
         <tabi:separator>
             {{  config.extra.separator | default(value="•") }}
@@ -30,6 +30,15 @@
         <tabi:post_listing_date>
             {{- config.extra.post_listing_date | default(value="date") -}}
         </tabi:post_listing_date>
+        <tabi:current_section>
+            {%- if term -%}
+                {{ term.name }}
+            {%- elif section.title -%}
+                {{ section.title }}
+            {%- else -%}
+                {{ config.title }}
+            {%- endif -%}
+        </tabi:current_section>
     </tabi:metadata>
 
     {#- Load extra CSS (skin) if set in config.toml -#}
@@ -47,7 +56,9 @@
     {%- endif %}
     <link href="{{ feed_url | safe }}" rel="self" type="application/atom+xml"/>
     <link href="
-        {%- if section -%}
+        {%- if term -%}
+            {{ term.permalink | escape_xml | safe }}
+        {%- elif section -%}
             {{ section.permalink | escape_xml | safe }}
         {%- else -%}
             {{ get_url(path="/", lang=lang) | escape_xml | safe }}


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Enhances the "Visit website" link in the Atom feed to be section-aware and properly link to the language-specific main page when not in a section or tag.

### Related issue

#393

## Changes

- Link to language-specific main site (used to always link to `/`)
- If the feed belongs to a tag, it displays it on the link (see screenshot)
- Add section/tag information to the Atom feed template
- Update XSL transformation to conditionally display section/tag

### Screenshots

![feed link](https://github.com/user-attachments/assets/310cd849-1767-436c-a734-7fd8cd76b979)

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [X] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [X] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
