### PR TITLE
✨ feat(remote_text shortcode): support relative paths

### DIFF
--- a/content/blog/shortcodes/index.ca.md
+++ b/content/blog/shortcodes/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Shortcodes personalitzats"
 date = 2023-02-19
-updated = 2024-08-28
+updated = 2024-09-22
 description = "Aquest tema inclou alguns shortcodes personalitzats útils que pots utilitzar per millorar les teves publicacions. Ja sigui per mostrar imatges que s'adapten als temes clar i fosc, o per donar format a una secció de referències amb un aspecte professional, aquests shortcodes personalitzats t'ajudaran."
 
 [taxonomies]
@@ -210,7 +210,7 @@ Afegeix text des d'una URL remota o un arxiu local.
 **Important**:
 
 - **Arxius remots VS arxius locals**: Si `src` comença amb "http", es tractarà com un arxiu remot. D'altra banda, s'assumeix que és una ruta d'arxiu local.
-- **Accés a arxius**: Atès que utilitza la funció [`load_data`](https://www.getzola.org/documentation/templates/overview/#load-data) de Zola, els arxius locals han d'estar dins del directori de Zola —vegeu la [lògica de cerca d'arxius](https://www.getzola.org/documentation/templates/overview/#file-searching-logic).
+- **Accés a arxius**: Atès que utilitza la funció [`load_data`](https://www.getzola.org/documentation/templates/overview/#load-data) de Zola, els arxius locals han d'estar dins del directori de Zola —vegeu la [lògica de cerca d'arxius](https://www.getzola.org/documentation/templates/overview/#file-searching-logic). Desde [tabi 2.16.0](https://github.com/welpo/tabi/releases/tag/v2.16.0), el shortcode admet també rutes relatives.
 - **Formateig de blocs de codi**: Per mostrar el text com un bloc de codi, has d'afegir manualment les tanques de codi Markdown (cometes inverses) i, opcionalment, especificar el llenguatge de programació per al ressaltat sintàctic.
 
 #### Ús

--- a/content/blog/shortcodes/index.ca.md
+++ b/content/blog/shortcodes/index.ca.md
@@ -207,6 +207,14 @@ dist/
 
 Afegeix text des d'una URL remota o un arxiu local.
 
+El shortcode accepta tres paràmetres:
+
+- `src`: L'URL d'origen o ruta del fitxer (obligatori)
+- `start`: Primera línia a mostrar (opcional, comença a 1)
+- `end`: Número de l'última línia (opcional, per defecte és 0, l'última línia)
+
+{{ admonition(type="info", text="`start` i `end` són inclusius. `start=3, end=3` mostrarà només la tercera línia.") }}
+
 **Important**:
 
 - **Arxius remots VS arxius locals**: Si `src` comença amb "http", es tractarà com un arxiu remot. D'altra banda, s'assumeix que és una ruta d'arxiu local.
@@ -227,6 +235,12 @@ Mostra el text d'un arxiu local:
 
 ```
 {{/* remote_text(src="ruta/a/arxiu.txt") */}}
+```
+
+Mostreu només les línies 3 a 5 d'un arxiu local:
+
+```
+{{/* remote_text(src="ruta/a/arxiu.txt", start=3, end=5) */}}
 ```
 
 ### Advertències

--- a/content/blog/shortcodes/index.es.md
+++ b/content/blog/shortcodes/index.es.md
@@ -208,6 +208,14 @@ dist/
 
 Añade texto desde una URL remota o un archivo local.
 
+El shortcode acepta tres parámetros:
+
+- `src`: La URL de origen o ruta del archivo (obligatorio)
+- `start`: Primera línea a mostrar (opcional, empieza en 1)
+- `end`: Número de la última línea (opcional, por defecto es 0, la última línea)
+
+{{ admonition(type="info", text="`start` y `end` son inclusivos. `start=3, end=3` mostrará solo la tercera línea.") }}
+
 **Importante**:
 
 - **Archivos remotos VS archivos locales**: Si `src` empieza con "http", se tratará como un archivo remoto. De lo contrario, se asume que es una ruta de archivo local.
@@ -228,6 +236,12 @@ Visualización de texto de un archivo local:
 
 ```
 {{/* remote_text(src="ruta/a/archivo.txt") */}}
+```
+
+Mostar sólo las líneas 3 a 5 de un archivo remoto:
+
+```
+{{/* remote_text(src="https://example.com/script.py", start=3, end=5) */}}
 ```
 
 ### Advertencias

--- a/content/blog/shortcodes/index.es.md
+++ b/content/blog/shortcodes/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Shortcodes personalizados"
 date = 2023-02-19
-updated = 2024-08-28
+updated = 2024-09-22
 description = "Este tema incluye algunos shortcodes personalizados útiles que puedes utilizar para mejorar tus publicaciones. Puedes mostrar imágenes que se adapten a los temas claro y oscuro, dar formato a una sección de referencias con un aspecto profesional, y más."
 
 [taxonomies]
@@ -211,7 +211,7 @@ Añade texto desde una URL remota o un archivo local.
 **Importante**:
 
 - **Archivos remotos VS archivos locales**: Si `src` empieza con "http", se tratará como un archivo remoto. De lo contrario, se asume que es una ruta de archivo local.
-- **Acceso a archivos**: Dado que utiliza la función [`load_data`](https://www.getzola.org/documentation/templates/overview/#load-data) de Zola, los archivos locales deben estar dentro del directorio de Zola —ver la [lógica de búsqueda de archivos](https://www.getzola.org/documentation/templates/overview/#file-searching-logic).
+- **Acceso a archivos**: Dado que utiliza la función [`load_data`](https://www.getzola.org/documentation/templates/overview/#load-data) de Zola, los archivos locales deben estar dentro del directorio de Zola —ver la [lógica de búsqueda de archivos](https://www.getzola.org/documentation/templates/overview/#file-searching-logic). Desde [tabi 2.16.0](https://github.com/welpo/tabi/releases/tag/v2.16.0), el shortcode admite también rutas relativas.
 - **Formateo de bloques de código**: Para mostrar el texto como un bloque de código, debes añadir manualmente las cercas de código Markdown (comillas invertidas) y, opcionalmente, especificar el lenguaje de programación para el resaltado sintáctico.
 
 #### Uso

--- a/content/blog/shortcodes/index.md
+++ b/content/blog/shortcodes/index.md
@@ -207,6 +207,14 @@ dist/
 
 Embed text from a remote URL or a local file. To display the path or URL on the code block, see the [show source or path shortcode](#show-source-or-path).
 
+The shortcode accepts three parameters:
+
+- `src`: The source URL or file path (required)
+- `start`: First line to display (optional, starts at 1)
+- `end`: The ending line number (optional, defaults to 0, meaning the last line)
+
+{{ admonition(type="info", text="`start` and `end` are inclusive. `start=3, end=3` will display only the third line.") }}
+
 **Important**:
 
 - **Remote VS local files**: If `src` starts with "http", it will be treated as a remote file. Otherwise, it assumes a local file path.
@@ -227,6 +235,12 @@ Displaying text from a local file:
 
 ```
 {{/* remote_text(src="path/to/file.txt") */}}
+```
+
+Display lines 3 to 7 (both inclusive) of a local file:
+
+```
+{{/* remote_text(src="path/to/file.txt", start=3, end=7) */}}
 ```
 
 ### Admonitions

--- a/content/blog/shortcodes/index.md
+++ b/content/blog/shortcodes/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Custom shortcodes"
 date = 2023-02-19
-updated = 2024-08-28
+updated = 2024-09-22
 description = "This theme includes some useful custom shortcodes that you can use to enhance your posts. Whether you want to display images that adapt to light and dark themes, or format a professional-looking reference section, these custom shortcodes have got you covered."
 
 [taxonomies]
@@ -210,7 +210,7 @@ Embed text from a remote URL or a local file. To display the path or URL on the 
 **Important**:
 
 - **Remote VS local files**: If `src` starts with "http", it will be treated as a remote file. Otherwise, it assumes a local file path.
-- **Files access**: As it uses Zola's [`load_data`](https://www.getzola.org/documentation/templates/overview/#load-data), local files must be inside the Zola directory—see [File searching logic](https://www.getzola.org/documentation/templates/overview/#file-searching-logic).
+- **Files access**: As it uses Zola's [`load_data`](https://www.getzola.org/documentation/templates/overview/#load-data), local files must be inside the Zola directory—see [File searching logic](https://www.getzola.org/documentation/templates/overview/#file-searching-logic). As of [tabi 2.16.0](https://github.com/welpo/tabi/releases/tag/v2.16.0), the shortcode supports both relative and absolute paths.
 - **Code block formatting**: To display the text as a code block, you must manually add the Markdown code fences (backticks) and, optionally, specify the programming language for syntax highlighting.
 
 #### Usage

--- a/templates/shortcodes/remote_text.html
+++ b/templates/shortcodes/remote_text.html
@@ -1,3 +1,6 @@
+{%- set start = start | default(value=1) -%}
+{%- set end = end | default(value=0) -%}
+
 {#- load_data uses different arguments based on whether it's a remote or local file -#}
 {%- if src is starting_with("http") -%}
     {%- set response = load_data(url=src, format="plain") -%}
@@ -11,4 +14,17 @@
         {%- set response = load_data(path=src, format="plain") -%}
     {%- endif -%}
 {%- endif -%}
-{{- response | trim_end | safe -}}
+
+{%- set lines = response | trim_end | split(pat="\n") -%}
+
+{%- if start > 0 -%}
+    {%- set start = start - 1 -%}
+{%- endif -%}
+
+{%- if end == 0 or end > lines | length -%}
+    {%- set end = lines | length -%}
+{%- endif -%}
+
+{%- set lines = lines | slice(start=start, end=end) -%}
+
+{{- lines | join(sep="\n") | safe -}}

--- a/templates/shortcodes/remote_text.html
+++ b/templates/shortcodes/remote_text.html
@@ -2,6 +2,13 @@
 {%- if src is starting_with("http") -%}
     {%- set response = load_data(url=src, format="plain") -%}
 {%- else -%}
-    {%- set response = load_data(path=src, format="plain") -%}
+    {#- Try to load the file from a relative path -#}
+    {%- set colocated_path = page.colocated_path | default(value="") -%}
+    {%- set relative_path = colocated_path ~ src -%}
+    {%- set response = load_data(path=relative_path, format="plain", required=false) -%}
+    {#- If relative path fails, try absolute path -#}
+    {%- if not response -%}
+        {%- set response = load_data(path=src, format="plain") -%}
+    {%- endif -%}
 {%- endif -%}
 {{- response | trim_end | safe -}}


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

This PR adds support for line range selection in the `remote_text` shortcode. Users can now specify start and end line numbers when embedding text from remote or local files.

### Related issue

Requested in #397.

## Changes

- Added `start` and `end` parameters to the `remote_text` shortcode
- Updated the shortcode to slice the text content based on these parameters
- Updated documentation to explain the new functionality
- Added examples demonstrating the use of line range selection

### Type of change

- [ ] Bug fix (fixes an issue without altering functionality)
- [X] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [x] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [x] Updated "Mastering tabi" post in English
  - [x] (Optional) Updated "Mastering tabi" post in Spanish
  - [x] (Optional) Updated "Mastering tabi" post in Catalan