### PR TITLE
🐛 [Bugfix] Update analytics.html for self hosting Umami

### DIFF
--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -644,7 +644,7 @@ Pots configurar-los en la secció `[extra.analytics]` del teu arxiu `config.toml
 - `service`: el servei a utilitzar. Les opcions disponibles són `"goatcounter"`, `"umami", i "plausible"`.
 
 - `id`: l'identificador únic per al teu servei d'anàlisi. Això varia segons el servei:
-  - Per a GoatCounter, és el codi triat durant el registre. Instàncies auto-allotjades no requereixen aquest camp.
+  - Per a GoatCounter, és el codi triat durant el registre. Instàncies auto-allotjades de GoatCounter no requereixen aquest camp.
   - Per a Umami, és l'ID del lloc web.
   - Per a Plausible, és el nom de domini.
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -644,7 +644,7 @@ Puedes configurarlos en la sección `[extra.analytics]` de tu archivo `config.to
 - `service`: el servicio a utilizar. Las opciones disponibles son `"goatcounter"`, `"umami"`, y `"plausible"`.
 
 - `id`: el identificador único para tu servicio de análisis. Esto varía según el servicio:
-  - Para GoatCounter, es el código elegido durante el registro. Instancias auto-alojadas no requieren este campo.
+  - Para GoatCounter, es el código elegido durante el registro. Instancias auto-alojadas de GoatCounter no requieren este campo.
   - Para Umami, es la ID del sitio web.
   - Para Plausible, es el nombre de dominio.
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -652,7 +652,7 @@ You can set them up in the `[extra.analytics]` section of your `config.toml`.
 - `service`: Specifies which analytics service to use. Supported options are `"goatcounter"`, `"umami"`, and `"plausible"`.
 
 - `id`: The unique identifier for your analytics service. This varies based on the service:
-  - For GoatCounter, it's the code chosen during signup. Self-hosted instances don't require this field.
+  - For GoatCounter, it's the code chosen during signup. Self-hosted instances of GoatCounter don't require this field.
   - For Umami, it's the website ID.
   - For Plausible, it's the domain name.
 

--- a/templates/partials/analytics.html
+++ b/templates/partials/analytics.html
@@ -20,7 +20,7 @@
     <script async defer
     {% if self_hosted_url %}
         data-website-id="{{ analytics_id }}"
-        src="{{ self_hosted_url ~ '/umami.js' }}"
+        src="{{ self_hosted_url ~ '/script.js' }}"
     {% else %}
         data-website-id="{{ analytics_id }}"
         src="https://analytics.eu.umami.is/script.js"

--- a/theme.toml
+++ b/theme.toml
@@ -280,7 +280,7 @@ enable_csp = true
 # For GoatCounter, this is the code you choose during signup.
 # For Umami, this is the website ID.
 # For Plausible, this is the domain name (e.g. "example.com").
-# Note: Leave this field empty if you're self-hosting.
+# Note: Leave this field empty if you're self-hosting GoatCounter.
 # id = "yourID"
 
 # Optional: Specify the URL for self-hosted analytics instances.


### PR DESCRIPTION
`umami.js` should be `script.js` for self hosting URL.

## Summary

- self hosting analytics for Umami fixed.

### Related issue

<!-- Mention any relevant issues like #123 -->

## Changes

File name changed

### Accessibility

<!-- Have you taken steps to make your changes accessible? This could include:
- Semantic HTML
- ARIA attributes
- Keyboard navigation
- Voiceover or screen reader compatibility
- Colour contrast
Please elaborate on the actions taken.
If you need help, please ask! -->

### Screenshots

<!-- If applicable, add screenshots to help explain the changes made. Consider if a before/after is helpful -->

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
