### PR TITLE
📝 docs: add mermaid shortcode usage

### DIFF
--- a/content/blog/shortcodes/index.ca.md
+++ b/content/blog/shortcodes/index.ca.md
@@ -91,6 +91,18 @@ El shortcode de Mermaid admet dos paràmetres:
 
 {{ admonition(type="tip", title="CONSELL", text="Empra l'[editor de Mermaid](https://mermaid.live/) per crear i previsualitzar els teus diagrames.") }}
 
+#### Ús
+
+```
+{%/* mermaid(invertible=true, full_width=false) */%}
+
+El teu codi Mermaid va aquí.
+
+`invertible` or `full_width` poden ometre's per emprar els valors per defecte.
+
+{%/* end */%}
+```
+
 ## Shortcodes d'imatge
 
 Tots els shortcodes d'imatge admeten rutes absolutes, rutes relatives, i fonts remotes en el paràmetre `src`.

--- a/content/blog/shortcodes/index.es.md
+++ b/content/blog/shortcodes/index.es.md
@@ -91,6 +91,16 @@ El shortcode de Mermaid admite dos parámetros:
 
 {{ admonition(type="tip", title="CONSEJO", text="Puedes usar el [editor de Mermaid](https://mermaid.live/) para crear y previsualizar tus diagramas.") }}
 
+#### Uso
+
+```
+{%/* mermaid(invertible=true, full_width=false) */%}
+
+Tu diagrama Mermaid va aquí. Puedes omitir los parámetros para usar los valores predeterminados.
+
+{%/* end */%}
+```
+
 ## Shortcodes de imagen
 
 Todos los shortcodes de imagen admiten rutas absolutas, rutas relativas, y fuentes remotas en el parámetro `src`.

--- a/content/blog/shortcodes/index.md
+++ b/content/blog/shortcodes/index.md
@@ -91,6 +91,18 @@ The Mermaid shortcode supports two parameters:
 
 {{ admonition(type="tip", text="You can use the [Mermaid Live Editor](https://mermaid.live/) to create and preview your diagrams.") }}
 
+#### Usage
+
+```
+{%/* mermaid(invertible=true, full_width=false) */%}
+
+Your diagram goes here.
+
+`invertible` or `full_width` can be omitted if default values are used.
+
+{%/* end */%}
+```
+
 ## Image shortcodes
 
 All image shortcodes support absolute paths, relative paths, and remote sources in the `src` parameter.


### PR DESCRIPTION
## Summary

Mermaid usage was missing in the documentation.
I just added it as for any other shortcode.

## Changes

Add mermaid usage in documentation

### Accessibility

Nothing particular for this change, just reused other similar shortcode usage as base.

### Screenshots

![image](https://github.com/user-attachments/assets/dab2ad1a-8714-4b80-9f32-45d54d80512d)

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [X] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [X] I have verified the accessibility of my changes
- [ ] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
