### PR TITLE
✨ feat: add fediverse creator metadata support

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -267,6 +267,11 @@ socials = [
     { name = "spotify", url = "https://open.spotify.com/artist/5Hv2bYBhMp1lUHFri06xkE", icon = "spotify" },
 ]
 
+# Fediverse profile.
+# Adds metadata to feature the author's profile in Mastodon link previews.
+# Example: for @username@example.com, use:
+# fediverse_creator = { handle = "username", domain = "example.com" }
+
 # Extra menu to show on the footer, below socials section.
 footer_menu = [
     {url = "about", name = "about", trailing_slash = true},

--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -470,6 +470,18 @@ Ja que segueix la [jerarquia](#jerarquia-de-configuracio), si no està configura
 
 **Consell**: automatitza la seva creació amb un [script](https://github.com/welpo/osc.garden/blob/main/static/code/social-cards-zola): [De reservat a rei de les xarxes: automatitzant les vistes prèvies dels enllaços amb Zola](https://osc.garden/ca/blog/automating-social-media-cards-zola/).
 
+### Creador del fedivers
+
+| Pàgina | Secció | `config.toml` | Segueix jerarquia | Requereix JavaScript |
+|:------:|:------:|:-------------:|:-----------------:|:--------------------:|
+|   ❌   |   ❌   |      ✅       |         ❌        |          ❌          |
+
+Pots mostrar el perfil del fedivers de l'autor en les previsualitzacions d'enllaços de Mastodon configurant la variable `fediverse_creator` al teu `config.toml`. Per exemple, per a @username@example.com, fes servir:
+
+```toml
+fediverse_creator = { handle = "username", domain = "example.com" }
+```
+
 ---
 
 ## Navegació

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -470,6 +470,18 @@ Dado que sigue la [jerarquía](#jerarquia-de-configuracion), si no está configu
 
 **Consejo**: automatiza su creación con un [script](https://github.com/welpo/osc.garden/blob/main/static/code/social-cards-zola): [De reservado a rey de las redes: automatizando las vistas previas de los enlaces con Zola](https://osc.garden/es/blog/automating-social-media-cards-zola/).
 
+### Creador del fediverso
+
+| Página | Sección | `config.toml` | Sigue jerarquía | Requiere JavaScript |
+|:------:|:-------:|:-------------:|:----------------:|:-------------------:|
+|   ❌   |    ❌   |      ✅       |        ❌        |         ❌          |
+
+Puedes mostrar tu perfil del fediverso en las vistas previas de enlaces de Mastodon configurando la variable `fediverse_creator` en tu `config.toml`. Por ejemplo, para @username@example.com, usa:
+
+```toml
+fediverse_creator = { handle = "username", domain = "example.com" }
+```
+
 ---
 
 ## Navegación

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -475,6 +475,20 @@ Since it follows the [hierarchy](#settings-hierarchy), if it's not set on a page
 
 **Protip**: automate their creation with a [script](https://github.com/welpo/osc.garden/blob/main/static/code/social-cards-zola): [From Bashful to Social Butterfly: Automating Link Previews for Zola Sites](https://osc.garden/blog/automating-social-media-cards-zola/).
 
+### Fediverse Creator
+
+| Page | Section | `config.toml` | Follows Hierarchy | Requires JavaScript |
+|:----:|:-------:|:-------------:|:-----------------:|:-------------------:|
+|  ❌  |   ❌    |      ✅       |         ❌        |         ❌          |
+
+You can highlight your fediverse profile in Mastodon link previews by setting the `fediverse_creator` variable in your `config.toml`. For example, for @username@example.com, use:
+
+```toml
+fediverse_creator = { handle = "username", domain = "example.com" }
+```
+
+This adds metadata to your HTML, allowing Mastodon to display the author's fediverse profile when your content is shared.
+
 ---
 
 ## Navigation

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -175,8 +175,8 @@
     {%- endif -%}
 
     {# Socials #}
-    {%- if config.extra.FediverseCreator -%}
-        <meta name="fediverse:creator" content="@{{ config.extra.FediverseCreator["handle"] }}@{{ config.extra.FediverseCreator["domain"]}}" />
+    {%- if config.extra.fediverse_creator -%}
+        <meta name="fediverse:creator" content="@{{ config.extra.fediverse_creator["handle"] }}@{{ config.extra.fediverse_creator["domain"]}}" />
     {%- endif -%}
 
     {# Search #}

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -174,6 +174,11 @@
         {%- include "partials/analytics.html" -%}
     {%- endif -%}
 
+    {# Socials #}
+    {%- if config.extra.FediverseCreator -%}
+        <meta name="fediverse:creator" content="@{{ config.extra.FediverseCreator["handle"] }}@{{ config.extra.FediverseCreator["domain"]}}" />
+    {%- endif -%}
+
     {# Search #}
     {%- if config.build_search_index -%}
         {%- if config.search.index_format -%}

--- a/theme.toml
+++ b/theme.toml
@@ -224,8 +224,10 @@ encode_plaintext_email = true  # Setting is ignored if email is already encoded.
 #     { name = "spotify", url = "https://open.spotify.com/artist/5Hv2bYBhMp1lUHFri06xkE", icon = "spotify" },
 # ]
 
-# Fediverse creator attribution
-# FediverseCreator = {  handle = "welpo", domain = "example.com" }
+# Fediverse profile.
+# Adds metadata to feature the author's profile in Mastodon link previews.
+# Example: for @username@example.com, use:
+# fediverse_creator = { handle = "username", domain = "example.com" }
 
 # Extra menu to show on the footer, below socials section.
 # footer_menu = [

--- a/theme.toml
+++ b/theme.toml
@@ -224,6 +224,9 @@ encode_plaintext_email = true  # Setting is ignored if email is already encoded.
 #     { name = "spotify", url = "https://open.spotify.com/artist/5Hv2bYBhMp1lUHFri06xkE", icon = "spotify" },
 # ]
 
+# Fediverse creator attribution
+# FediverseCreator = {  handle = "welpo", domain = "example.com" }
+
 # Extra menu to show on the footer, below socials section.
 # footer_menu = [
 #     {url = "about", name = "about", trailing_slash = true},


### PR DESCRIPTION
## Summary

Add Fediverse author meta tag to header through variable `fediverse_creator`.

### Related issue

#408 

## Changes

- Added conditional insert of meta tag to header template

### Accessibility

Meta-element, should not impact accessibility?

### Screenshots

Live at https://www.richtman.au

### Type of change

- [ ] Bug fix (fixes an issue without altering functionality)
- [x] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [ ] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [x] Updated `config.toml` comments
  - [x] Updated `theme.toml` comments
  - [x] Updated "Mastering tabi" post in English
  - [x] (Optional) Updated "Mastering tabi" post in Spanish
  - [x] (Optional) Updated "Mastering tabi" post in Catalan
