### PR TITLE
💄 style: improve navigation bar & metadata wrapping

### DIFF
--- a/sass/parts/_header.scss
+++ b/sass/parts/_header.scss
@@ -24,13 +24,15 @@ header {
 .nav-navs {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
+    gap: 1px;
 
     ul {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: center;
-        align-items: center;
-        gap: 1px;
+        display: inherit;
+        flex-wrap: inherit;
+        justify-content: inherit;
+        align-items: inherit;
+        gap: inherit;
         margin: 0;
         padding: 0;
         list-style: none;
@@ -76,11 +78,18 @@ header {
 
     ul,
     li {
-        display: inline;
+        display: inline-block;
+        margin-inline-end: 0.2rem;
         font-family: var(--sans-serif-font);
         list-style-type: none;
     }
+
+    .separator {
+        margin-inline-end: 0.2rem;
+        user-select: none;
+    }
 }
+
 .language-switcher {
     display: flex;
     justify-content: center;

--- a/sass/parts/_header.scss
+++ b/sass/parts/_header.scss
@@ -25,18 +25,24 @@ header {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 1px;
 
     ul {
-        display: inherit;
+        display: flex;
         flex-wrap: inherit;
         justify-content: inherit;
         align-items: inherit;
         gap: inherit;
+        gap: 1px;
         margin: 0;
         padding: 0;
         list-style: none;
     }
+}
+
+#menu-icons-group {
+    gap: 1px;
+    margin: 0;
+    padding: 0;
 }
 
 .nav-links {
@@ -160,21 +166,17 @@ header {
 
     .nav-navs {
         display: flex;
-        justify-content: flex-end;
+        justify-content: center;
     }
 }
 
 @media only screen and (max-width: 600px) {
     .nav-navs {
-        flex-wrap: wrap;
-        justify-content: center;
         margin-top: 0.8rem;
-        width: 100%;
     }
 
     .navbar {
         flex-direction: column;
-        justify-content: center;
         align-items: center;
     }
 }

--- a/sass/parts/_header.scss
+++ b/sass/parts/_header.scss
@@ -84,6 +84,10 @@ header {
         list-style-type: none;
     }
 
+    .tag {
+        margin-inline-end: 0;
+    }
+
     .separator {
         margin-inline-end: 0.2rem;
         user-select: none;

--- a/templates/page.html
+++ b/templates/page.html
@@ -140,7 +140,7 @@ Current section extra: {% if current_section %}{{ current_section.extra | json_e
                 {%- set previous_visible = true -%}
             {% endif %}
 
-            {%- set separator_with_class = "<span class='separator'>" ~ separator ~ "</span>"-%}
+            {%- set separator_with_class = "<span class='separator' aria-hidden='true'>" ~ separator ~ "</span>"-%}
 
             {#- Date -#}
             {% if page.date and macros_settings::evaluate_setting_priority(setting="show_date", page=page, default_global_value=true) == "true" %}
@@ -157,9 +157,9 @@ Current section extra: {% if current_section %}{{ current_section.extra | json_e
 
             {#- Tags -#}
             {%- if page.taxonomies and page.taxonomies.tags -%}
-                <li>{%- if previous_visible -%}{{ separator_with_class | safe }}{%- endif -%}{{- macros_translate::translate(key="tags", default="tags", language_strings=language_strings) | capitalize -}}:&nbsp;</li>
+                <li class="tag">{%- if previous_visible -%}{{ separator_with_class | safe }}{%- endif -%}{{- macros_translate::translate(key="tags", default="tags", language_strings=language_strings) | capitalize -}}:&nbsp;</li>
                 {%- for tag in page.taxonomies.tags -%}
-                    <li><a href="{{ get_taxonomy_url(kind='tags', name=tag, lang=lang) | safe }}">{{ tag }}</a>
+                    <li class="tag"><a href="{{ get_taxonomy_url(kind='tags', name=tag, lang=lang) | safe }}">{{ tag }}</a>
                     {%- if not loop.last -%}
                         ,&nbsp;
                     {%- endif -%}

--- a/templates/page.html
+++ b/templates/page.html
@@ -140,22 +140,24 @@ Current section extra: {% if current_section %}{{ current_section.extra | json_e
                 {%- set previous_visible = true -%}
             {% endif %}
 
+            {%- set separator_with_class = "<span class='separator'>" ~ separator ~ "</span>"-%}
+
             {#- Date -#}
             {% if page.date and macros_settings::evaluate_setting_priority(setting="show_date", page=page, default_global_value=true) == "true" %}
-                {%- if previous_visible -%}&nbsp;{{ separator }}&nbsp;{%- endif -%}<li>{{ macros_format_date::format_date(date=page.date, short=true, language_strings=language_strings) }}</li>
+                <li>{%- if previous_visible -%}{{ separator_with_class | safe }}{%- endif -%}{{ macros_format_date::format_date(date=page.date, short=true, language_strings=language_strings) }}</li>
                 {#- Variable to keep track of whether we've shown a section, to avoid separators as the first element -#}
                 {%- set previous_visible = true -%}
             {% endif %}
 
             {#- Reading time -#}
             {% if macros_settings::evaluate_setting_priority(setting="show_reading_time", page=page, default_global_value=true) == "true" %}
-                {%- if previous_visible -%}&nbsp;{{ separator }}&nbsp;{%- endif -%}<li title="{{ macros_translate::translate(key="words", number=page.word_count, default="$NUMBER words", language_strings=language_strings) }}">{{ macros_translate::translate(key="min_read", number=page.reading_time, default="$NUMBER min read", language_strings=language_strings) }}</li>
+                <li title="{{ macros_translate::translate(key="words", number=page.word_count, default="$NUMBER words", language_strings=language_strings) }}">{%- if previous_visible -%}{{ separator_with_class | safe }}{%- endif -%}{{ macros_translate::translate(key="min_read", number=page.reading_time, default="$NUMBER min read", language_strings=language_strings) }}</li>
                 {%- set previous_visible = true -%}
             {% endif %}
 
             {#- Tags -#}
             {%- if page.taxonomies and page.taxonomies.tags -%}
-                {%- if previous_visible -%}&nbsp;{{ separator }}&nbsp;{%- endif -%}<li>{{- macros_translate::translate(key="tags", default="tags", language_strings=language_strings) | capitalize -}}:&nbsp;</li>
+                <li>{%- if previous_visible -%}{{ separator_with_class | safe }}{%- endif -%}{{- macros_translate::translate(key="tags", default="tags", language_strings=language_strings) | capitalize -}}:&nbsp;</li>
                 {%- for tag in page.taxonomies.tags -%}
                     <li><a href="{{ get_taxonomy_url(kind='tags', name=tag, lang=lang) | safe }}">{{ tag }}</a>
                     {%- if not loop.last -%}
@@ -174,8 +176,7 @@ Current section extra: {% if current_section %}{{ current_section.extra | json_e
                 </ul><ul class="meta last-updated"><li>{{ updated_str }}</li>
                 {# Show link to remote changes if enabled #}
                 {% if config.extra.remote_repository_url and macros_settings::evaluate_setting_priority(setting="show_remote_changes", page=page, default_global_value=true) == "true" %}
-                    {%- if previous_visible -%}{{ separator }}&nbsp;{%- endif -%}
-                    <li><a href="{% include "partials/history_url.html" %}" {{ blank_target }} rel="{{ rel_attributes }}">{{ macros_translate::translate(key="see_changes", default="See changes", language_strings=language_strings) }}<small>&nbsp;<span class="arrow-corner">↗</span></small></a></li>
+                    <li>{%- if previous_visible -%}{{ separator_with_class | safe }}{%- endif -%}<a href="{% include "partials/history_url.html" %}" {{ blank_target }} rel="{{ rel_attributes }}">{{ macros_translate::translate(key="see_changes", default="See changes", language_strings=language_strings) }}<small>&nbsp;<span class="arrow-corner">↗</span></small></a></li>
                 {% endif %}
             {% endif %}
         </ul>

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -18,28 +18,31 @@
                         {% endfor %}
                     {%- endif -%}
 
-                    {# Search #}
-                    {%- if config.build_search_index %}
-                    {%- set search_icon_title = macros_translate::translate(key='search_icon_title', default='Press $SHORTCUT to open search', language_strings=language_strings) -%}
-                    <li class="js">
-                        <div role="button" tabindex="0" id="search-button" class="search-icon interactive-icon" title="{{ search_icon_title }}" aria-label="{{ search_icon_title }}">
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">
-                                <path d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z"/>
-                            </svg>
-                        </div>
-                    </li>
-                    {%- endif %}
+                    {#- Wrap the icons in a div to keep them all together -#}
+                    <div class="nav-navs">
+                        {# Search #}
+                        {%- if config.build_search_index %}
+                        {%- set search_icon_title = macros_translate::translate(key='search_icon_title', default='Press $SHORTCUT to open search', language_strings=language_strings) -%}
+                        <li class="js">
+                            <div role="button" tabindex="0" id="search-button" class="search-icon interactive-icon" title="{{ search_icon_title }}" aria-label="{{ search_icon_title }}">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">
+                                    <path d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z"/>
+                                </svg>
+                            </div>
+                        </li>
+                        {%- endif %}
 
-                    {# Language switcher #}
-                    {# Display the language switcher only if more than one language is available #}
-                    {%- if config.languages | length > 0 %}
-                    {% include "partials/language_switcher.html" %}
-                    {%- endif %}
+                        {# Language switcher #}
+                        {# Displayed only if more than one language is available #}
+                        {%- if config.languages | length > 0 %}
+                        {% include "partials/language_switcher.html" %}
+                        {%- endif %}
 
-                    {# Theme switcher #}
-                    {%- if config.extra.theme_switcher and config.extra.theme_switcher == true -%}
-                    {%- include "partials/theme_switcher.html" -%}
-                    {%- endif -%}
+                        {# Theme switcher #}
+                        {%- if config.extra.theme_switcher and config.extra.theme_switcher == true -%}
+                        {%- include "partials/theme_switcher.html" -%}
+                        {%- endif -%}
+                    </div>
                 </ul>
             </div>
         {% endif %}

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -19,7 +19,7 @@
                     {%- endif -%}
 
                     {#- Wrap the icons in a div to keep them all together -#}
-                    <div class="nav-navs">
+                    <div class="nav-navs" id="menu-icons-group">
                         {# Search #}
                         {%- if config.build_search_index %}
                         {%- set search_icon_title = macros_translate::translate(key='search_icon_title', default='Press $SHORTCUT to open search', language_strings=language_strings) -%}


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Improves wrapping of navigation bar icons —grouping them together for wrapping— and post metadata (see screenshots).

## Changes

- Group wrapped navigation icons
- Make metadata 'separator' unselectable
- Better wrapping of article metadata:
  - Tags never get split
  - Separator uses a class instead of non-breaking spaces
  - Elements are joined with their separator
  - Elements starting in a new line (due to wrapping), do not get space before the separator

### Accessibility

Improved: adds `aria-hidden="true"` to the separator. This prevents screen readers from announcing decorative content that could be distracting or redundant.

The list structure (`<li>` elements) already provides sufficient context for understanding that these are related but separate pieces of information. Before, the screen reader would announce something like "January 1, 2024 bullet 5 min read". With `aria-hidden="true"`, the screen reader would simply announce: "January 1, 2024 5 min read"

Tabbing works as before.

### Screenshots

#### Before

![beefore](https://github.com/user-attachments/assets/607df530-6d8b-40e8-8e8f-a5cdbc72ca04)

Note:
- lone theme switcher icon

#### After

![aafter](https://github.com/user-attachments/assets/3355fc36-2446-4cdd-8dca-0a260a1f1e6d)

#### Before

![before2](https://github.com/user-attachments/assets/061f5711-834d-4bbb-88be-b220f3184159)

Note:
- "5 min read" odd wrapping
- "FAQ" tag wrapped mid-word

#### After

![after2](https://github.com/user-attachments/assets/344a05ea-8962-46dc-8233-46bbafd23663)

Note how the Tags separator starts where one would expect. Before, with the forced non-breaking spaces, it would include space before the separator.

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [X] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [X] I have verified the accessibility of my changes
- [X] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
