### PR TITLE
💄 style: set accent color to match theme

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -98,6 +98,8 @@
     --serif-font: 'Source Serif', 'Georgia', serif;
     --code-font: 'Cascadia Code';
 
+    accent-color: var(--primary-color);
+
     line-height: 190%;
     font-family: var(--sans-serif-font);
 }


### PR DESCRIPTION
## Summary

Added `accent-color` CSS variable to style form elements (checkboxes, radio buttons, range inputs) consistently with the theme's primary color.

## Changes

Added `accent-color: var(--primary-color);` to the global styles. This affects:
- Checkboxes
- Radio buttons
- Range inputs
- Progress bars

Respects the use of skins or custom CSS.

### Screenshots

Before:

![before](https://github.com/user-attachments/assets/27ad517d-a5bf-469c-84a0-c4d0ed06ff7d)

Uses the OS accent colour (pink, for me)

After:

![aaafter](https://github.com/user-attachments/assets/c8534d2b-f97a-4bcd-b77f-b85efe326877)

Uses the `primary-color` variable.

### Type of change

- [ ] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [x] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] Updated "Mastering tabi" post in Spanish
  - [ ] Updated "Mastering tabi" post in Catalan