### PR TITLE
💄 style: colour scrollbar to match primary colour

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -98,6 +98,7 @@
     --serif-font: 'Source Serif', 'Georgia', serif;
     --code-font: 'Cascadia Code';
 
+    scrollbar-color: var(--primary-color) transparent;
     accent-color: var(--primary-color);
 
     line-height: 190%;


### PR DESCRIPTION
## Summary

Added `scrollbar-color` CSS variable to style scrollbars consistently with the theme's primary color. Respects the use of custom CSS / skins.

### Related issue

Same goal as #429: theme cohesion.

## Changes

Added `scrollbar-color: var(--primary-color) transparent;` to the global styles for custom scrollbar styling that matches the theme.

### Screenshots

![scroll](https://github.com/user-attachments/assets/45ff7803-5407-461f-8cb7-f67f9de986ee)

### Type of change

- [ ] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [x] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
 - [ ] Updated `config.toml` comments
 - [ ] Updated `theme.toml` comments
 - [ ] Updated "Mastering tabi" post in English
 - [ ] Updated "Mastering tabi" post in Spanish
 - [ ] Updated "Mastering tabi" post in Catalan