### PR TITLE
💄 style: fix home banner layout for short intro

### DIFF
--- a/sass/parts/_home-banner.scss
+++ b/sass/parts/_home-banner.scss
@@ -1,7 +1,7 @@
 #banner-container-home {
     display: flex;
-    justify-content: center;
-    align-items: center;
+    justify-content: space-between;
+    align-items: flex-start;
     margin: 0.2rem auto;
     width: 100%;
 
@@ -11,6 +11,7 @@
     }
 
     #home-banner-text {
+        flex: 1;
         margin-block-end: 1.5rem;
         color: var(--primary-color);
         font-size: 1.875rem;
@@ -53,9 +54,9 @@
 
     #image-container-home {
         position: relative;
+        margin: auto 0;
         padding-inline-start: 2rem;
-        min-width: 11rem;
-        min-height: 11rem;
+        max-width: 11rem;
         overflow: hidden;
         text-align: center;
 
@@ -63,9 +64,8 @@
             border: none;
             aspect-ratio: 1 / 1;
             width: 100%;
-            max-width: 15rem;
-            height: auto;
-            max-height: 15rem;
+            height: 100%;
+            object-fit: cover;
 
             @media only screen and (max-width: 600px) {
                 max-width: 12rem;
@@ -75,6 +75,8 @@
 
         @media only screen and (max-width: 600px) {
             padding-inline-start: 0;
+            width: 100%;
+            max-width: none;
         }
     }
 }


### PR DESCRIPTION
## Summary

Improves home banner balance when displaying shorter intro texts.

Before, setting a brief intro text would center the container and enlarge the image.

### Screenshots

Before:

![b](https://github.com/user-attachments/assets/14b23110-eb0f-4904-84aa-00d64f510993)

After:

![a](https://github.com/user-attachments/assets/91ef4c5e-2d07-4e1f-8904-82342230a34c)

### Type of change

- [ ] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [x] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan