### PR TITLE
✨ feat: support using info-page.html for sections

### DIFF
--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuració de tabi: guia completa"
 date = 2023-09-18
-updated = 2024-11-30
+updated = 2025-01-02
 description = "Descobreix les múltiples maneres en què pots personalitzar tabi."
 
 [taxonomies]
@@ -489,6 +489,17 @@ path = "about"
 ```
 
 Fixa't com s'estableix `path = "about"`. Zola situarà la pàgina a `$base_url/about/`. Si vols que la pàgina estigui disponible a `/contacte/`, hauries d'establir `path = "contacte"`.
+
+La plantilla `info-page.html` també es pot utilitzar per crear landing pages a la ruta arrel (`"/"`). Per fer-ho, l'arxiu `content/_index.md` hauria de ser així:
+
+```markdown
++++
+title = "Títol de la pàgina"
+template = "info-page.html"
++++
+
+Contingut amb Markdown.
+```
 
 ---
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuración de tabi: guía completa"
 date = 2023-09-18
-updated = 2024-11-30
+updated = 2025-01-02
 description = "Descubre las múltiples maneras en que puedes personalizar tabi."
 
 [taxonomies]
@@ -489,6 +489,17 @@ path = "about"
 ```
 
 Fíjate cómo se establece `path = "about"`. Zola colocará la página en `$base_url/about/`. Si deseas que la página esté disponible en `/contacto/`, tendrías que establecer `path = "contacto"`.
+
+La plantilla `info-page.html` también se puede utilizar para crear lading pages en la ruta raíz (`"/"`). Para hacerlo, el archivo `content/_index.md` debería verse así:
+
+```markdown
++++
+title = "Título de la página"
+template = "info-page.html"
++++
+
+Contenido con Markdown.
+```
 
 ---
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -495,6 +495,17 @@ path = "about"
 
 Notice how the `path` is set to `about`. Zola will place the page at `$base_url/about/`. If you'd like to have the page available at `/contact/`, you'd set `path = "contact"`.
 
+The `info-page.html` template can also be used to create landing pages at the path root (`"/"`). To do that, the `content/_index.md` file should look like this:
+
+```markdown
++++
+title = "Landing Page Title"
+template = "info-page.html"
++++
+
+Place your landing page Markdown content here.
+```
+
 ---
 
 ## SEO

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Mastering tabi Settings: A Comprehensive Guide"
 date = 2023-09-18
-updated = 2024-11-30
+updated = 2025-01-02
 description = "Discover the many ways you can customise your tabi site."
 
 [taxonomies]

--- a/templates/info-page.html
+++ b/templates/info-page.html
@@ -4,13 +4,15 @@
 
 {%- block main_content %}
 
-{{ macros_page_header::page_header(title=page.title) }}
+{%- set page_or_section = page | default(value=section) -%}
+
+{{ macros_page_header::page_header(title=page_or_section.title) }}
 
 <div id="page-content">
     <main>
         {# The replace pattern is used to enable arbitrary locations for the Table of Contents #}
         {# This is Philipp Oppermann's workaround: https://github.com/getzola/zola/issues/584#issuecomment-474329637 #}
-        {{ page.content | replace(from="<!-- toc -->", to=macros_toc::toc(page=page, header=false, language_strings=language_strings)) | safe }}
+        {{ page_or_section.content | replace(from="<!-- toc -->", to=macros_toc::toc(page=page_or_section, header=false, language_strings=language_strings)) | safe }}
     </main>
 </div>
 

--- a/templates/partials/extra_features.html
+++ b/templates/partials/extra_features.html
@@ -1,6 +1,11 @@
 {%- set page_or_section = page | default(value=section) -%}
+
+{# prepare parameters for evaluate_setting_priority macro #}
+{%- set page_s = page | default(value="") -%}
+{%- set section_s = section | default(value="") -%}
+
 {# Quick navigation buttons #}
-{% if macros_settings::evaluate_setting_priority(setting="quick_navigation_buttons", page=page_or_section, default_global_value=false) == "true" %}
+{% if macros_settings::evaluate_setting_priority(setting="quick_navigation_buttons", page=page_s, section=section_s, default_global_value=false) == "true" %}
     <div id="button-container">
         {# Button to go show a floating Table of Contents #}
         {% if page_or_section.toc %}
@@ -31,13 +36,13 @@
 {% endif %}
 
 {# Add KaTeX functionality #}
-{%- if macros_settings::evaluate_setting_priority(setting="katex", page=page_or_section, default_global_value=false) == "true" -%}
+{%- if macros_settings::evaluate_setting_priority(setting="katex", page=page_s, section=section_s, default_global_value=false) == "true" -%}
     <link rel="stylesheet" href="{{ get_url(path='katex.min.css', trailing_slash=false) | safe }}">
     <script defer src="{{ get_url(path='js/katex.min.js', trailing_slash=false) | safe }}"></script>
 {%- endif -%}
 
 {# Load mermaid.js #}
-{%- if macros_settings::evaluate_setting_priority(setting="mermaid", page=page_or_section, default_global_value=false) == "true" -%}
+{%- if macros_settings::evaluate_setting_priority(setting="mermaid", page=page_s, section=section_s, default_global_value=false) == "true" -%}
     {%- if config.extra.serve_local_mermaid | default(value=true) -%}
         <script defer src="{{ get_url(path='js/mermaid.min.js', trailing_slash=false) | safe }}"></script>
     {%- else -%}
@@ -46,7 +51,7 @@
 {%- endif -%}
 
 {# Add copy button to code blocks #}
-{%- if macros_settings::evaluate_setting_priority(setting="copy_button", page=page_or_section, default_global_value=true) == "true" -%}
+{%- if macros_settings::evaluate_setting_priority(setting="copy_button", page=page_s, section=section_s, default_global_value=true) == "true" -%}
     {#- Add hidden HTML elements with the translated strings for the button's interactions -#}
     <span id="copy-success" class="hidden">
         {{ macros_translate::translate(key="copied", default="Copied!", language_strings=language_strings) }}
@@ -58,11 +63,11 @@
 {%- endif -%}
 
 {# JavaScript to use the "Show source or path" on code blocks shortcode: https://welpo.github.io/tabi/blog/shortcodes/#show-source-or-path #}
-{%- if macros_settings::evaluate_setting_priority(setting="add_src_to_code_block", page=page_or_section, default_global_value=false) == "true" -%}
+{%- if macros_settings::evaluate_setting_priority(setting="add_src_to_code_block", page=page_s, section=section_s, default_global_value=false) == "true" -%}
     <script defer src="{{ get_url(path='js/addSrcToCodeBlock.min.js', trailing_slash=false) | safe }}"></script>
 {%- endif -%}
 
 {# Add backlinks to footnotes #}
-{%- if macros_settings::evaluate_setting_priority(setting="footnote_backlinks", page=page_or_section, default_global_value=false) == "true" -%}
+{%- if macros_settings::evaluate_setting_priority(setting="footnote_backlinks", page=page_s, section=section_s, default_global_value=false) == "true" -%}
     <script defer src="{{ get_url(path='js/footnoteBacklinks.min.js', trailing_slash=false | safe )}}"></script>
 {%- endif -%}


### PR DESCRIPTION
## Summary
This change makes it possible to use the `info-page.html` template on the root path (`"/"`), which in zola is always a "section" and can't be set to "page".

The related issue(s) is/are actually in zola and not really in tabi. It's a known limitation in zola that the root path has to be a section and can't be a page (see linked issues later). Because of that templates designed for pages typically can't be used for sections (and thus not as a root path "/" landing page).

Thankfully in tabi a lot of things are already pretty agnostic between sections and pages, so it only needed some minor tweaks to make the template work at the root level.

### Related issues

As said before, not really a tabi issue, but here are related zola issues and discussions:

- https://github.com/getzola/zola/issues/2334
- https://github.com/getzola/zola/issues/2553
- https://github.com/getzola/zola/issues/2101
- https://github.com/getzola/zola/issues/1119
- https://zola.discourse.group/t/page-content-not-available-in-content-root/534

#### Slightly related (but very old / fixed / obsolete)

- https://github.com/getzola/zola/issues/836
- https://github.com/getzola/zola/issues/99

## Changes

### `extra-features.html`
Before this change, this partial failed to render for sections, because it called the macro `evaluate_setting_priority` with the section as page parameter which caused the line `{%- for i in range(start=1, end=components | length) -%}` to fail, because `start` (1) was larger than the `end` (0) parameter.

It looked to me like the section parameter was added later to `evaluate_setting_priority` (because it has a default value and the parameter documentation is missing) so I made a change in `extra-features.html` to pass page and section separately if they are set (or `""` if they are not set).

### `info-page.html`
I updated the `info-page.html` to also support both pages and sections.

### Screenshots

<!-- If applicable, add screenshots to help explain the changes made. Consider if a before/after is helpful -->

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [x] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
    - Changes in `extra-features.html` should be backwards compatible, but I'm not 100% sure.
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [ ] I have tested all possible scenarios for this change
    - I don't think that's possible without manually checking all sites that use tabi 😄 
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [x] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [x] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
