### PR TITLE
🐛 fix(feed): load CSS in subfolder setups

### DIFF
--- a/static/feed_style.xsl
+++ b/static/feed_style.xsl
@@ -14,7 +14,13 @@
         <meta charset="utf-8"/>
         <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
-        <link rel="stylesheet" href="{/atom:feed/@xml:base}/main.css"/>
+        <!-- The base URL is assumed to be the first URL in the sitemap. -->
+        <xsl:variable name="baseUrl" select="(sitemap:urlset/sitemap:url)[1]/sitemap:loc"/>
+        <!-- Remove http[s]:// -->
+        <xsl:variable name="baseUrlWithoutProtocol" select="substring-after($baseUrl, '://')"/>
+        <!-- Remove trailing slash -->
+        <xsl:variable name="clean_base_url" select="substring-before($baseUrlWithoutProtocol, '/')"/>
+        <link rel="stylesheet" href="{$baseUrl}main.css"/>
         <link rel="stylesheet" href="{/atom:feed/atom:link[@rel='extra-stylesheet']/@href}" />
 
       </head>


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Fixes CSS loading in subfolder installations by deriving the base path from the feed URL instead of relying on xml:base. Uses same logic as sitemap styling.

### Related issue

N/A

### Screenshots

Before:

![before, no styling](https://github.com/user-attachments/assets/8ec063b4-f09f-42f0-8e9d-9562a1c67583)

After:

![after, css is loaded](https://github.com/user-attachments/assets/e25b8c59-4fa6-4809-8b10-404946c302f1)

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---
## Checklist
- [ ] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan