### PR TITLE
🔒️ fix(header): reposition include of CSP partial

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -1,5 +1,10 @@
 <head>
     <meta charset="UTF-8">
+
+    {%- if macros_settings::evaluate_setting_priority(setting="enable_csp", page=page | default(value=""), section=section | default(value=""), default_global_value="true") == "true" -%}
+        {%- include "partials/content_security_policy.html" -%}
+    {%- endif -%}
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="base" content="{{ config.base_url | safe }}">
 
@@ -129,10 +134,6 @@
     {%- endif -%}
 
     <meta property="og:site_name" content="{{ config.title }}">
-
-    {%- if macros_settings::evaluate_setting_priority(setting="enable_csp", page=page | default(value=""), section=section | default(value=""), default_global_value="true") == "true" -%}
-        {%- include "partials/content_security_policy.html" -%}
-    {%- endif -%}
 
     {%- if config.extra.theme_switcher and config.extra.theme_switcher == true -%}
         {# If JavaScript is disabled, hide the button. #}


### PR DESCRIPTION
## Summary

Move the Content Security Policy partial to be included closeer to the top of `<head>` in order to protect additional resources.

### Related issue

None

## Changes

Per the [CSP spec on delivering Content Security Policy using the meta element](https://www.w3.org/TR/CSP/#meta-element):

> Authors are strongly encouraged to place meta elements as early in the document as possible, because policies in meta elements are not  applied to content which precedes them. In particular, note that resources fetched or prefetched using the Link HTTP response header field, and resources fetched or prefetched using link and script elements which precede a meta-delivered policy will not be blocked.

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have tested all possible scenarios for this change