### PR TITLE
💄 style(fonts): change font fallback implementation

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -25,26 +25,23 @@
 @use 'parts/_zola-error.scss';
 
 @font-face {
-    src: local('Inter'),
-        url('fonts/Inter4.woff2') format("woff2");
+    src: url('fonts/Inter4.woff2') format("woff2");
     /* Copyright 2016 The Inter Project Authors (https://github.com/rsms/inter). Licensed under the SIL Open Font License, Version 1.1. More information available at: http://scripts.sil.org/OFL */
-    font-family: 'Inter';
+    font-family: 'Inter subset';
     font-display: swap;
 }
 
 @font-face {
-    src: local('Source Serif'),
-        url('fonts/SourceSerif4Variable-Roman.ttf.woff2') format("woff2");
+    src: url('fonts/SourceSerif4Variable-Roman.ttf.woff2') format("woff2");
     /* Copyright 2014 - 2023 Adobe (http://www.adobe.com/), with Reserved Font Name ‘Source’.adobe.com/). Licensed under the SIL Open Font License, Version 1.1. More information available at: http://scripts.sil.org/OFL */
-    font-family: 'Source Serif';
+    font-family: 'Source Serif subset';
     font-display: swap;
 }
 
 @font-face {
-    src: local('Cascadia Code'),
-        url('fonts/CascadiaCode-SemiLight.woff2') format("woff2");
+    src: url('fonts/CascadiaCode-SemiLight.woff2') format("woff2");
     /* Copyright 2019 - Present, Microsoft Corporation, with Reserved Font Name 'Cascadia Code'. Licensed under the SIL Open Font License, Version 1.1. More information available at: http://scripts.sil.org/OFL */
-    font-family: 'Cascadia Code';
+    font-family: 'Cascadia Code subset';
     font-display: swap;
 }
 
@@ -95,9 +92,9 @@
     --small-layout-width: 200px;
     --paragraph-spacing: max(2.3vmin, 24px);
 
-    --sans-serif-font: 'Inter', Helvetica, Arial, sans-serif;
-    --serif-font: 'Source Serif', 'Georgia', serif;
-    --code-font: 'Cascadia Code';
+    --sans-serif-font: 'Inter', 'Inter subset', Helvetica, Arial, sans-serif;
+    --serif-font: 'Source Serif', 'Source Serif subset', 'Georgia', serif;
+    --code-font: 'Cascadia Code', 'Cascadia Code subset';
 
     scrollbar-color: var(--primary-color) transparent;
     accent-color: var(--primary-color);


### PR DESCRIPTION
## Summary

Instead of defining fall back from local font to URL download in `@font-face` at-rules, implement fall back more in the `font-family` font stacks.

Using the font-family is the simplest way to allow the browser to fully use local font families, including italic fonts.

Using custom font-family names in the `@font-face` rules avoids conflict with well-known font families so that the custom subsets will only be referenced explicitly, not unintentionally.

### Related issue

#472

## Changes

Move the prioritisation of local fonts from @font-face to the main CSS font-family declarations and use custom font-family names in the @font-face at-rules. For example, change from:

```scss
--code-font: 'Cascadia Code';

@font-face {
    src: local('Cascadia Code'),
        url('fonts/CascadiaCode-SemiLight.woff2') format("woff2");
    font-family: 'Cascadia Code';
}
```

To:

```scss
--code-font: 'Cascadia Code', 'Cascadia Code subset';

@font-face {
    src: url('fonts/CascadiaCode-SemiLight.woff2') format("woff2");
    font-family: 'Cascadia Code subset';
}
```

The fallback functions the same but:

- When the font family is found locally all fonts can be used (e.g. regular and italic styles), without needing to write multiple `@font-face` rules.
- Anyone using custom CSS can use the common font families like `Cascadia Code` without having knowledge of tabi implementation

Notable differences that could be considered notable or possibly breaking changes:

- If the local italic fonts are now used then italic text may be rendered differently to before (which had italics faked by the browser by slanting the regular font)
    - I think this is more expected behaviour
- If anyone had custom CSS using the font families `Inter`, `Source Serif`, or `Cascadia Code` then they will no longer have a fallback to the theme-bundled subsets.
    - I don't expect that the fallback when using these font families would be expected and used in custom CSS, but you never know

### Screenshots

Before the tabi site viewed on Windows has a local regular font for italic text in code block:
![before](https://github.com/user-attachments/assets/f46146b0-0959-4152-a6c1-3627a5d69d57)

After, the italics are rendered with the local italic font:
![after](https://github.com/user-attachments/assets/d0316e05-2097-46b8-b128-322339edf5cd)

On a Mac when I override the fonts with my desired font stack I can see `Menlo Italic` being used, with no requests to download fonts.

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [x] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this chane