### PR TITLE
🐛 fix: support external URLs in menu

### DIFF
--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuració de tabi: guia completa"
 date = 2023-09-18
-updated = 2025-01-12
+updated = 2025-02-02
 description = "Descobreix les múltiples maneres en què pots personalitzar tabi."
 
 [taxonomies]
@@ -587,7 +587,9 @@ fediverse_creator = { handle = "username", domain = "example.com" }
 |:------:|:------:|:-------------:|:---------------:|:-------------------:|
 |   ❌   |   ❌   |      ✅       |        ❌       |         ❌          |
 
-La barra de navegació és la franja a la part superior de la pàgina que conté el títol del lloc i el menú de navegació. Pots personalitzar els elements que apareixen configurant `menu` en `config.toml`. Per exemple:
+La barra de navegació és la franja a la part superior de la pàgina que conté el títol del lloc i el menú de navegació. Pots personalitzar els elements que apareixen configurant `menu` en `config.toml`.
+
+Soporta links relatius per a pàgines internes i links absoluts per a enllaços externs. Per exemple:
 
 ```toml
 menu = [
@@ -596,6 +598,7 @@ menu = [
     { name = "etiquetes", url = "tags", trailing_slash = true },
     { name = "projectes", url = "projects", trailing_slash = true },
     { name = "sobre nosaltres", url = "about", trailing_slash = true },
+    { name = "github", url = "https://github.com/welpo/tabi", trailing_slash = false },
 ]
 ```
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuración de tabi: guía completa"
 date = 2023-09-18
-updated = 2025-01-12
+updated = 2025-02-02
 description = "Descubre las múltiples maneras en que puedes personalizar tabi."
 
 [taxonomies]
@@ -587,7 +587,9 @@ fediverse_creator = { handle = "username", domain = "example.com" }
 |:------:|:-------:|:-------------:|:---------------:|:-------------------:|
 |   ❌   |   ❌    |      ✅       |        ❌       |         ❌          |
 
-La barra de navegación es la barra en la parte superior de la página que contiene el título del sitio y el menú de navegación. Puedes personalizar los elementos que aparecen configurando `menu` en `config.toml`. Por ejemplo:
+La barra de navegación es la barra en la parte superior de la página que contiene el título del sitio y el menú de navegación. Puedes personalizar los elementos que aparecen configurando `menu` en `config.toml`.
+
+Soporta links relativos para páginas internas y links absolutos para enlaces externos. Por ejemplo:
 
 ```toml
 menu = [
@@ -596,6 +598,7 @@ menu = [
     { name = "etiquetas", url = "tags", trailing_slash = true },
     { name = "proyectos", url = "projects", trailing_slash = true },
     { name = "acerca de", url = "about", trailing_slash = true },
+    { name = "github", url = "https://github.com/welpo/tabi", trailing_slash = false },
 ]
 ```
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Mastering tabi Settings: A Comprehensive Guide"
 date = 2023-09-18
-updated = 2025-01-12
+updated = 2025-02-02
 description = "Discover the many ways you can customise your tabi site."
 
 [taxonomies]
@@ -594,7 +594,9 @@ This adds metadata to your HTML, allowing Mastodon to display the author's fediv
 |:----:|:-------:|:-------------:|:-----------------:|:-------------------:|
 |  ❌  |   ❌    |      ✅       |         ❌        |         ❌          |
 
-The navigation bar is the bar at the top of the page that contains the site title and the navigation menu. You can customise which items appear by setting `menu` in `config.toml`. For example:
+The navigation bar is the bar at the top of the page that contains the site title and the navigation menu. You can customise which items appear by setting `menu` in `config.toml`.
+
+The menu supports both relative URLs for internal pages and absolute URLs for external links. For example:
 
 ```toml
 menu = [
@@ -603,6 +605,7 @@ menu = [
     { name = "tags", url = "tags", trailing_slash = true },
     { name = "projects", url = "projects", trailing_slash = true },
     { name = "about", url = "about", trailing_slash = true },
+    { name = "github", url = "https://github.com/welpo/tabi", trailing_slash = false },
 ]
 ```
 

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -11,7 +11,15 @@
                         {% for menu in config.extra.menu %}
                             <li>
                                 {% set trailing_slash = menu.trailing_slash | default(value=true) %}
-                                <a class="nav-links no-hover-padding" href="{{ get_url(path=menu.url, lang=lang, trailing_slash=trailing_slash) }}">
+                                {%- if menu.url is starting_with("http") -%}
+                                    {%- if trailing_slash -%}
+                                        <a class="nav-links no-hover-padding" href="{{ menu.url }}/">
+                                    {%- else -%}
+                                        <a class="nav-links no-hover-padding" href="{{ menu.url }}">
+                                    {%- endif -%}
+                                {%- else -%}
+                                    <a class="nav-links no-hover-padding" href="{{ get_url(path=menu.url, lang=lang, trailing_slash=trailing_slash) }}">
+                                {%- endif -%}
                                 {{ macros_translate::translate(key=menu.name, default=menu.name, language_strings=language_strings) }}
                                 </a>
                             </li>


### PR DESCRIPTION
## Summary

Fix navigation menu handling of external URLs and update documentation to clarify external URL support.

### Related issue

Fixes #480

## Changes

This PR fixes a bug where external URLs in the navigation menu were being treated as relative URLs, resulting in incorrect paths like `http://127.0.0.1:1111/https://example.com/`. The fix:

1. Adds URL type detection to check if URLs start with "http"
2. Handles external URLs directly without using `get_url()`
3. Updates documentation to clarify external URL support and usage

This implements the same fix that was previously applied to the footer menu (#212).

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [x] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [x] I have made corresponding changes to the documentation:
 - [ ] Updated `config.toml` comments
 - [ ] Updated `theme.toml` comments
 - [x] Updated "Mastering tabi" post in English
 - [x] (Optional) Updated "Mastering tabi" post in Spanish
 - [x] (Optional) Updated "Mastering tabi" post in Catalan