### PR TITLE
💥 feat(archive)!: enforce chronological sorting

### DIFF
--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuració de tabi: guia completa"
 date = 2023-09-18
-updated = 2025-02-02
+updated = 2025-02-09
 description = "Descobreix les múltiples maneres en què pots personalitzar tabi."
 
 [taxonomies]
@@ -438,10 +438,14 @@ Per defecte, l'arxiu llistarà les publicacions situades a `blog/`. Per personal
   section_path = ["blog/", "notes/", "camí-tres/"]
   ```
 
-**Nota**:
+L'arxiu mostra les publicacions en ordre cronològic invers (les més recents primer). Pots invertir aquest ordre establint `archive_reverse = true` a la secció `[extra]`:
 
-- La pàgina d'arxiu només llistarà publicacions amb data.
-- L'ordre de les publicacions ve determinada per la variable `sort_by` de les seccions arxivades. Aquesta demo utilitza `sort_by = "date"` en `blog/_index.md`.
+```toml
+[extra]
+archive_reverse = true  # mostra les publicacions més antigues primer
+```
+
+{{ admonition(type="note", title="nota" text="La pàgina d'arxiu només llistarà publicacions que tinguin data al seu encapçalament.") }}
 
 ### Etiquetes
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuración de tabi: guía completa"
 date = 2023-09-18
-updated = 2025-02-02
+updated = 2025-02-09
 description = "Descubre las múltiples maneras en que puedes personalizar tabi."
 
 [taxonomies]
@@ -438,10 +438,14 @@ Por defecto, el archivo mostrará las publicaciones ubicadas en `blog/`. Para pe
   section_path = ["blog/", "notas/", "ruta-tres/"]
   ```
 
-**Nota**:
+El archivo muestra las publicaciones en orden cronológico inverso (las más recientes primero). Puedes invertir este orden estableciendo `archive_reverse = true` en la sección `[extra]`:
 
-- La página de Archivo sólo listará publicaciones con fecha.
-- El orden las publicaciones viene determinada por la variable `sort_by` de las secciones archivadas. Esta demo utiliza `sort_by = "date"` en `blog/_index.md`.
+```toml
+[extra]
+archive_reverse = true  # muestra las publicaciones más antiguas primero
+```
+
+{{ admonition(type="note", title="nota" text="La página de Archivo sólo listará publicaciones que tengan fecha en su encabezado.") }}
 
 ### Etiquetas
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Mastering tabi Settings: A Comprehensive Guide"
 date = 2023-09-18
-updated = 2025-02-02
+updated = 2025-02-09
 description = "Discover the many ways you can customise your tabi site."
 
 [taxonomies]
@@ -443,10 +443,14 @@ By default, the archive will list posts located in `blog/`. To customise this, y
   section_path = ["blog/", "notes/", "path-three/"]
   ```
 
-**Notes**:
+The archive displays posts in reverse chronological order (newest first). You can reverse this order by setting `archive_reverse = true` in the `[extra]` section:
 
-- the Archive page will only list posts that have a date in their front matter.
-- Post sorting is determined by the `sort_by` variable of the sections you are archiving. This demo uses `sort_by = "date"` set in the `blog/_index.md`.
+```toml
+[extra]
+archive_reverse = true  # displays oldest posts first.
+```
+
+{{ admonition(type="note", text="The Archive page will only list posts that have a date in their front matter.") }}
 
 ### Tags
 

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -25,6 +25,13 @@
             {%- set_global all_posts = all_posts | concat(with=section_item.pages) -%}
         {%- endfor %}
 
+        {# Sort all posts by date #}
+        {%- set archive_reverse = section.extra.archive_reverse | default(value=false) -%}
+        {%- set all_posts = all_posts | sort(attribute="date") -%}
+        {%- if not archive_reverse -%}
+            {%- set all_posts = all_posts | reverse -%}
+        {%- endif -%}
+
         {# Group posts by year. #}
         {% set posts_by_year = all_posts | group_by(attribute="year") %}
         {% set years = [] %}
@@ -32,8 +39,13 @@
             {% set_global years = years | concat(with=[year]) %}
         {% endfor %}
 
-        {# Iterate over sorted & reversed years (newest to oldest). #}
-        {% for year in years | sort | reverse %}
+        {# Iterate over years #}
+        {% set years = years | sort %}
+        {%- if not archive_reverse -%}
+            {%- set years = years | reverse -%}
+        {%- endif -%}
+
+        {% for year in years %}
             {% set posts = posts_by_year[year] %}
             {% if posts | length > 0 %}
             <li>


### PR DESCRIPTION
## Summary

> [!WARNING]
> Archive now enforces a `date`-based ordering. It used to respect the archived sections `order_by` value.

Enforces chronological sorting in the archive template and adds a configurable sort direction via `archive_reverse`. This change ensures consistent date-based ordering across all archive posts, regardless of their source sections' sorting configurations.

Since an archive is (1) inherently date-related, and (2) only post dates (not update dates) are shown, I believe this (breaking) change makes sense. Do let me know if you think otherwise.

> [!NOTE]
> Would you like the archive to support different sorting options for your site? [Open a feature request](https://github.com/welpo/tabi/issues/new?template=3_feature_request.yml) and let me know!

## Changes

- Enforces publication date sorting for all posts in archive, ignoring section-specific `sort_by` settings
- Adds `archive_reverse` option in `section.extra` to control sort direction
- When `archive_reverse = true`, displays oldest content first (both years and posts)
- When `archive_reverse = false` (default), displays newest content first
- Ensures year grouping follows the same ordering as posts

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [X] New feature (adds non-breaking functionality)
- [X] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [X] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [X] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [X] Updated "Mastering tabi" post in English
  - [X] (Optional) Updated "Mastering tabi" post in Spanish
  - [X] (Optional) Updated "Mastering tabi" post in Catalan
