### PR TITLE
✨ feat: render markdown in page titles & descriptions

### DIFF
--- a/templates/archive.html
+++ b/templates/archive.html
@@ -58,7 +58,7 @@
                                 {{ post.date | date(format="%d %b", locale=date_locale) }}
                             </span>
                         </div>
-                        <a href="{{ post.permalink }}" title="{{ post.title }}">{{ post.title }}</a>
+                        <a href="{{ post.permalink }}" title="{{ post.title }}">{{ post.title | markdown | safe }}</a>
                     </li>
                     {% endfor %}
                 </ul>

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -58,7 +58,7 @@
                                 {{ post.date | date(format="%d %b", locale=date_locale) }}
                             </span>
                         </div>
-                        <a href="{{ post.permalink }}" title="{{ post.title }}">{{ post.title | markdown | safe }}</a>
+                        <a href="{{ post.permalink }}" title="{{ post.title }}">{{ post.title | markdown(inline=true) | safe }}</a>
                     </li>
                     {% endfor %}
                 </ul>

--- a/templates/page.html
+++ b/templates/page.html
@@ -108,7 +108,7 @@ Current section extra: {% if current_section %}{{ current_section.extra | json_e
 <main>
     <article>
         <h1 class="article-title">
-            {{ page.title | markdown | safe }}
+            {{ page.title | markdown(inline=true) | safe }}
         </h1>
 
         <ul class="meta">
@@ -297,13 +297,13 @@ Current section extra: {% if current_section %}{{ current_section.extra | json_e
                 <div>
                 {%- if left_link and left_label and left_title -%}
                 <a href="{{ left_link | safe }}" aria-label="{{ left_label }}" aria-describedby="left_title"><span class="arrow">←</span>&nbsp;{{ left_label }}</a>
-                <p aria-hidden="true" id="left_title">{{ left_title | truncate(length=100, end="…") | markdown | safe }}</p>
+                <p aria-hidden="true" id="left_title">{{ left_title | truncate(length=100, end="…") | markdown(inline=true) | safe }}</p>
                 {%- endif -%}
                 </div>
                 <div>
                 {%- if right_link and right_label and right_title -%}
                 <a href="{{ right_link | safe }}" aria-label="{{ right_label }}" aria-describedby="right_title">{{ right_label }}&nbsp;<span class="arrow">→</span></a>
-                <p aria-hidden="true" id="right_title">{{ right_title | truncate(length=100, end="…") | markdown | safe }}</p>
+                <p aria-hidden="true" id="right_title">{{ right_title | truncate(length=100, end="…") | markdown(inline=true) | safe }}</p>
                 {%- endif -%}
                 </div>
             </nav>

--- a/templates/page.html
+++ b/templates/page.html
@@ -108,7 +108,7 @@ Current section extra: {% if current_section %}{{ current_section.extra | json_e
 <main>
     <article>
         <h1 class="article-title">
-            {{ page.title }}
+            {{ page.title | markdown | safe }}
         </h1>
 
         <ul class="meta">
@@ -297,13 +297,13 @@ Current section extra: {% if current_section %}{{ current_section.extra | json_e
                 <div>
                 {%- if left_link and left_label and left_title -%}
                 <a href="{{ left_link | safe }}" aria-label="{{ left_label }}" aria-describedby="left_title"><span class="arrow">←</span>&nbsp;{{ left_label }}</a>
-                <p aria-hidden="true" id="left_title">{{ left_title | truncate(length=100, end="…") }}</p>
+                <p aria-hidden="true" id="left_title">{{ left_title | truncate(length=100, end="…") | markdown | safe }}</p>
                 {%- endif -%}
                 </div>
                 <div>
                 {%- if right_link and right_label and right_title -%}
                 <a href="{{ right_link | safe }}" aria-label="{{ right_label }}" aria-describedby="right_title">{{ right_label }}&nbsp;<span class="arrow">→</span></a>
-                <p aria-hidden="true" id="right_title">{{ right_title | truncate(length=100, end="…") }}</p>
+                <p aria-hidden="true" id="right_title">{{ right_title | truncate(length=100, end="…") | markdown | safe }}</p>
                 {%- endif -%}
                 </div>
             </nav>

--- a/templates/partials/cards_pages.html
+++ b/templates/partials/cards_pages.html
@@ -38,10 +38,10 @@
             {% endif %}
 
             <div class="card-info">
-                <h2 class="card-title">{{ page.title }}</h2>
+                <h2 class="card-title">{{ page.title | markdown | safe }}</h2>
                 <div class="card-description">
                     {% if page.description %}
-                        {{ page.description }}
+                        {{ page.description | markdown | safe }}
                     {% endif %}
                 </div>
             </div>

--- a/templates/partials/cards_pages.html
+++ b/templates/partials/cards_pages.html
@@ -38,10 +38,10 @@
             {% endif %}
 
             <div class="card-info">
-                <h2 class="card-title">{{ page.title | markdown | safe }}</h2>
+                <h2 class="card-title">{{ page.title | markdown(inline=true) | safe }}</h2>
                 <div class="card-description">
                     {% if page.description %}
-                        {{ page.description | markdown | safe }}
+                        {{ page.description | markdown(inline=true) | safe }}
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
## Summary

I added `safe` and `markdown` filters to some pages because I couldn't use Markdown and HTML formatting in titles and descriptions (like _italic_ or `<em>italic</em>`) - they was rendering "as-is" and not interpreted as I wanted to see them.

### Related issue

This PR resolves issue #468 

### Screenshots

![card](https://github.com/user-attachments/assets/33ed86ea-69e2-473a-83f4-96cc19075837)

![article](https://github.com/user-attachments/assets/d891edb3-352d-4ef8-b061-5652c328536b)

![footer](https://github.com/user-attachments/assets/839947c9-f4fb-425f-8cd4-3b2848b66c88)


### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
