### PR TITLE
💄 fix: fix external link icon breaking word wrapping

### DIFF
--- a/sass/parts/_misc.scss
+++ b/sass/parts/_misc.scss
@@ -85,30 +85,21 @@ a {
 // External link styles with `external_links_class = "external"`.
 main {
     --external-link-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'%3E%3Cpath d='M11 5h-6v14h14v-6'/%3E%3Cpath d='M13 11l7 -7'/%3E%3Cpath d='M21 3h-6M21 3v6'/%3E%3C/g%3E%3C/svg%3E");
-    a.external:not(:has(img, svg, video, picture, figure)) {
-        display: inline-block;
-        padding-inline-end: 0.9em;
-    }
 
     a.external:not(:has(img, svg, video, picture, figure))::after {
-        -webkit-mask-image: var(--external-link-icon);
-        -webkit-mask-size: 100% 100%;
         display: inline-block;
-        position: absolute;
-        top: 50%;
-        transform: translateY(-50%);
-        mask-image: var(--external-link-icon);
-        mask-size: 100% 100%;
-        margin-inline-start: 0.2em;
-        inset-inline-end: 0;
+        vertical-align: -0.05em;
+        margin-inline-start: 0.1em;
         background-color: currentColor;
         width: 0.8em;
         height: 0.8em;
         content: '';
+        -webkit-mask-image: var(--external-link-icon);
+        -webkit-mask-size: 100% 100%;
     }
 
     &:dir(rtl) a.external:not(:has(img, svg, video, picture, figure))::after {
-        transform: translateY(-50%) rotate(-90deg);
+        transform: rotate(-90deg);
     }
 
     .meta a.external:not(:has(img, svg, video, picture, figure))::after {


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

This PR fixes the external link icon breaking word wrapping on long link text. Previously, links with the external icon would be treated as a single unbreakable unit, causing awkward line breaks.

### Related issue

Fixes #495

## Changes

The root cause was the `display: inline-block` property applied to external links. This change:
- Removes the `display: inline-block` property from external links
- Adjusts the icon implementation to use `inline-block` only on the pseudo-element

### Accessibility

Unaffected/improved.

### Screenshots

#### Before

![bbefore](https://github.com/user-attachments/assets/44f387a0-a4f1-42a4-9f15-c92995272f27)

#### After

![aafter](https://github.com/user-attachments/assets/b9cda7a8-3286-4838-ae6c-e03cdbeef06a)

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [x] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan