### PR TITLE
✨ feat(indieweb): add hidden h-card

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -427,3 +427,21 @@ avatar = true
 voting = true
 page_author_hashes = ""  # hash (or list of hashes) of the author.
 lazy_loading = true  # Loads when the comments are in the viewport (using the Intersection Observer API).
+
+# h-card configuration
+# will identify you on the indieweb (see https://microformats.org/wiki/h-card)
+[extra.hcard]
+# enable = true # Enables the h-card on the home page
+# with_mail = false        # Add your email to the card if extra.email is set and not encoded
+# with_social_links = true # Add your social links to the card
+# homepage = "https://myhomepage.net" # Homepage url, default to the value of 'base_url'
+# avatar = "img/profile.webp"
+# full_name = "John Doe" # Display name, default to the value of 'author'
+# biography = "Fond of the indieweb" # Small bio, as shown on social media profiles 
+#
+# You can add any property from https://microformats.org/wiki/h-card#Properties
+# Make sure to replace all '-' characters by '_'
+# Below are some examples
+# p_nickname = "nickname"
+# p_locality = "Bordeaux"
+# p_country_name = "France"

--- a/config.toml
+++ b/config.toml
@@ -429,19 +429,25 @@ page_author_hashes = ""  # hash (or list of hashes) of the author.
 lazy_loading = true  # Loads when the comments are in the viewport (using the Intersection Observer API).
 
 # h-card configuration
-# will identify you on the indieweb (see https://microformats.org/wiki/h-card)
+# Will identify you on the indieweb (see https://microformats.org/wiki/h-card)
 [extra.hcard]
-# enable = true # Enables the h-card on the home page
-# with_mail = false        # Add your email to the card if extra.email is set and not encoded
-# with_social_links = true # Add your social links to the card
-# homepage = "https://myhomepage.net" # Homepage url, default to the value of 'base_url'
+# Enable home page h-card.
+# enable = true
+# Add your email to the card if extra.email is set and not encoded.
+# with_mail = true
+# Add your social links ('socials' config) to the card.
+# with_social_links = true
+# Homepage url. Defaults to the value of 'base_url'.
+# homepage = "https://myhomepage.net"
 # avatar = "img/profile.webp"
-# full_name = "John Doe" # Display name, default to the value of 'author'
-# biography = "Fond of the indieweb" # Small bio, as shown on social media profiles 
+# Display name, default to the value of 'author'.
+# full_name = "John Doe"
+# Small bio, as shown on social media profiles.
+# biography = "Fond of the indieweb"
 #
 # You can add any property from https://microformats.org/wiki/h-card#Properties
 # Make sure to replace all '-' characters by '_'
-# Below are some examples
+# Examples:
 # p_nickname = "nickname"
 # p_locality = "Bordeaux"
 # p_country_name = "France"

--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuració de tabi: guia completa"
 date = 2023-09-18
-updated = 2025-02-16
+updated = 2025-04-05
 description = "Descobreix les múltiples maneres en què pots personalitzar tabi."
 
 [taxonomies]
@@ -1004,6 +1004,26 @@ allowed_domains = [
 Aquesta opció està habilitada per defecte. Per desactivar-la per una pàgina, secció o globalment, estableix `enable_csp = false`. La configuració de `enable_csp` segueix la jerarquia.
 
 Per a més informació, consulta la [pàgina de documentació de CSP](@/blog/security/index.ca.md).
+
+---
+
+## Indieweb
+
+### h-card representativa
+
+| Pàgina | Secció | `config.toml` | Segueix la jerarquia | Requereix JavaScript |
+| :--: | :-----: | :-----------: | :---------------: | :-----------------: |
+|  ❌  |   ❌    |      ✅       |        ❌         |         ❌          |
+
+Per defecte, tabi afegeix una h-card representativa [h-card](https://microformats.org/wiki/h-card) **oculta** a la pàgina d'inici. Tot i que és invisible per als visitants, està disponible per als analitzadors de microformats. Pots comprovar la validesa de la targeta amb l'eina [Indiewebify.me](https://indiewebify.me/validate-h-card/).
+
+Per desactivar l'h-card, estableix `enable = false` a la secció `[extra.hcard]` de `config.toml`.
+
+L'h-card predeterminada inclou el teu nom, l'URL del lloc web i els enllaços a les xarxes socials.
+
+Pots establir una imatge de perfil i una petita biografia amb els paràmetres `avatar` i `biography`.
+
+Totes les altres [propietats h-card](https://microformats.org/wiki/h-card#Properties) es poden afegir llistant-les a la secció `[extra.hcard]` del fitxer de configuració. Simplement substitueix tots els caràcters `-` per `_`.
 
 ---
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuración de tabi: guía completa"
 date = 2023-09-18
-updated = 2025-02-16
+updated = 2025-04-05
 description = "Descubre las múltiples maneras en que puedes personalizar tabi."
 
 [taxonomies]
@@ -1005,6 +1005,26 @@ allowed_domains = [
 Esta función está habilitada por defecto. Para deshabilitarla (y permitir todo), configura `enable_csp = false` en una página, sección o globalmente. La opción `enable_csp` sigue [la jerarquía](#jerarquia-de-configuracion).
 
 Para obtener más información, consulta la [página de documentación de CSP](@/blog/security/index.es.md).
+
+---
+
+## Indieweb
+
+### h-card representativa
+
+| Página | Sección | `config.toml` | Sigue Jerarquía | Requiere JavaScript |
+| :--: | :-----: | :-----------: | :---------------: | :-----------------: |
+|  ❌  |   ❌    |      ✅       |        ❌         |         ❌          |
+
+Por defecto, tabi añade una [h-card](https://microformats.org/wiki/h-card) representativa **oculta** a la página de inicio. Aunque es invisible para los visitantes, está disponible para los analizadores de microformatos. Puedes comprobar la validez de la tarjeta con la herramienta [Indiewebify.me](https://indiewebify.me/validate-h-card/).
+
+Para desactivar la h-card, establece `enable = false` en la sección `[extra.hcard]` de `config.toml`.
+
+La h-card predeterminada incluye tu nombre, la URL del sitio web y los enlaces a redes sociales.
+
+Puedes establecer una imagen de perfil y una pequeña biografía con los ajustes `avatar` y `biography`.
+
+Todas las demás [propiedades de h-card](https://microformats.org/wiki/h-card#Properties) se pueden añadir listándolas en la sección `[extra.hcard]` del archivo de configuración. Simplemente reemplaza todos los caracteres `-` por `_`.
 
 ---
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Mastering tabi Settings: A Comprehensive Guide"
 date = 2023-09-18
-updated = 2025-04-02
+updated = 2025-04-04
 description = "Discover the many ways you can customise your tabi site."
 
 [taxonomies]
@@ -113,7 +113,7 @@ The description is regular Markdown content, set outside the front matter.
 
 #### Listing Recent Posts
 
-To show posts on your main page, you first need to decide where these posts will be served from: the root path (`/`) or a subdirectory (e.g., `/blog`). 
+To show posts on your main page, you first need to decide where these posts will be served from: the root path (`/`) or a subdirectory (e.g., `/blog`).
 
 **Option A: Serve posts from the root path (`/`)**
 
@@ -1026,12 +1026,14 @@ See the [CSP documentation page](@/blog/security/index.md) for more information.
 | :--: | :-----: | :-----------: | :---------------: | :-----------------: |
 |  ❌  |   ❌    |      ✅       |        ❌         |         ❌          |
 
-Tabi adds a representative [h-card](https://microformats.org/wiki/h-card) to the homepage out of the box. It is hidden to the naked eye, but remains visible by microformat parsers. You can check the validity of the card with the [Indiewebify.me](https://indiewebify.me/validate-h-card/) tool.
+By default, tabi adds a **hidden** representative [h-card](https://microformats.org/wiki/h-card) to the homepage. While invisible to visitors, it's available to microformat parsers. You can check the validity of the card with the [Indiewebify.me](https://indiewebify.me/validate-h-card/) tool.
 
-It is possible to disable the h-card by setting `enable = false` in the `[extra.hcard]` section of the config file.
+To disable the h-card, set `enable = false` in the `[extra.hcard]` section of `config.toml`.
 
 The default h-card includes your name, website url and social media links.
+
 You can set a profile picture and a small bio with the `avatar` and `biography` settings.
+
 All other [h-card properties](https://microformats.org/wiki/h-card#Properties) can be added by listing them under the `[extra.hcard]`section of the config file. Simply replace all `-` characters by `_`.
 
 ---

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Mastering tabi Settings: A Comprehensive Guide"
 date = 2023-09-18
-updated = 2025-02-16
+updated = 2025-04-02
 description = "Discover the many ways you can customise your tabi site."
 
 [taxonomies]
@@ -1015,6 +1015,24 @@ allowed_domains = [
 This feature is enabled by default. To disable it (and allow all connections), set `enable_csp = false` on a page, section or globally. The `enable_csp` setting follows the [hierarchy](#settings-hierarchy).
 
 See the [CSP documentation page](@/blog/security/index.md) for more information.
+
+---
+
+## Indieweb
+
+### Representative h-card
+
+| Page | Section | `config.toml` | Follows Hierarchy | Requires JavaScript |
+| :--: | :-----: | :-----------: | :---------------: | :-----------------: |
+|  ❌  |   ❌    |      ✅       |        ❌         |         ❌          |
+
+Tabi adds a representative [h-card](https://microformats.org/wiki/h-card) to the homepage out of the box. It is hidden to the naked eye, but remains visible by microformat parsers. You can check the validity of the card with the [Indiewebify.me](https://indiewebify.me/validate-h-card/) tool.
+
+It is possible to disable the h-card by setting `enable = false` in the `[extra.hcard]` section of the config file.
+
+The default h-card includes your name, website url and social media links.
+You can set a profile picture and a small bio with the `avatar` and `biography` settings.
+All other [h-card properties](https://microformats.org/wiki/h-card#Properties) can be added by listing them under the `[extra.hcard]`section of the config file. Simply replace all `-` characters by `_`.
 
 ---
 

--- a/templates/partials/hcard.html
+++ b/templates/partials/hcard.html
@@ -1,0 +1,70 @@
+{%- set hcard = config.extra.hcard -%}
+
+{% set full_name = config.author %}
+{% if hcard.full_name %}
+  {% set full_name = hcard.full_name %}
+{% endif %}
+
+{%- set homepage = config.base_url -%}
+{% if hcard.homepage %}
+  {%- set homepage = hcard.homepage -%}
+{% endif %}
+
+{% if hcard.enable %}
+<div class="h-card hidden">
+  <div>
+    {%- if hcard.avatar -%}
+    <img
+      class="u-photo"
+      src="{{ get_url(path=hcard.avatar) }}"
+      width="200"
+      height="200"
+      alt="{{ full_name }}"
+    />
+    {%- endif -%}
+
+    <span class="p-name" rel="me">{{ full_name }}</span>
+
+    {% if hcard.p_nickname %}
+    ( <span class="p-nickname">{{ hcard.p_nickname }}</span> )
+    {% endif %}
+  </div>
+
+  {% if hcard.biography %}
+  <p class="p-note">{{ hcard.biography }}</p>
+  {% endif %}
+
+  {# links #}
+  <div>
+    {%- if hcard.with_mail and config.extra.email and not config.extra.encode_plaintext_email -%}
+    <span>
+      <a class="u-email" href="mailto:{{ config.extra.email | safe }}">email</a>
+    </span> -
+    {%- endif -%}
+
+    <span>
+      <a class="u-url u-id" href="{{ homepage }}">homepage</a>
+    </span> -
+
+    {%- if hcard.with_social_links and config.extra.socials %}
+      {% for social in config.extra.socials %}
+      <span>
+        <a class="p-url" rel="me" href="{{ social.url | safe }}">{{ social.name }}</a>
+      </span> -
+      {% endfor %}
+    {% endif %}
+  </div>
+
+  {# additional properties #}
+  <dl>
+  {% for key, value in hcard %}
+    {# exclude all properties previously displayed #}
+    {% if key not in ['enable', 'with_mail', 'with_social_links', 'homepage', 'full_name', 'avatar', 'biography', 'p_nickname'] %} 
+      <dt>{{ key | replace(from="p_", to="") | replace(from="u_", to="") | replace(from="dt_", to="") | replace(from="_", to=" ") | capitalize }}</dt>
+      <dd class="{{ key | replace(from="_", to="-") }}">{{ value }}</dd>
+    {% endif %}
+  {% endfor %}
+  </dl>
+
+</div>
+{% endif %}

--- a/templates/partials/hcard.html
+++ b/templates/partials/hcard.html
@@ -56,15 +56,18 @@
   </div>
 
   {# additional properties #}
-  <dl>
+  {% set dl_started = false %}
   {% for key, value in hcard %}
-    {# exclude all properties previously displayed #}
-    {% if key not in ['enable', 'with_mail', 'with_social_links', 'homepage', 'full_name', 'avatar', 'biography', 'p_nickname'] %} 
+    {% if key not in ['enable', 'with_mail', 'with_social_links', 'homepage', 'full_name', 'avatar', 'biography', 'p_nickname'] %}
+      {% if not dl_started %}
+        <dl>
+        {% set dl_started = true %}
+      {% endif %}
       <dt>{{ key | replace(from="p_", to="") | replace(from="u_", to="") | replace(from="dt_", to="") | replace(from="_", to=" ") | capitalize }}</dt>
       <dd class="{{ key | replace(from="_", to="-") }}">{{ value }}</dd>
     {% endif %}
   {% endfor %}
-  </dl>
-
-</div>
+  {% if dl_started %}
+    </dl>
+  {% endif %}
 {% endif %}

--- a/templates/section.html
+++ b/templates/section.html
@@ -24,6 +24,9 @@
 {%- endif -%}
 
 <main {% if more_than_one_section_shown %}class="{{ first_section }}-first"{% endif %}>
+{%- if config.extra.hcard %}
+    {%- include "partials/hcard.html" -%}
+{% endif -%}
 {%- if section.extra.header %}
     {%- include "partials/home_banner.html" -%}
 {%- elif section.content -%}

--- a/theme.toml
+++ b/theme.toml
@@ -377,19 +377,25 @@ custom_subset = true
 # lazy_loading = true  # Loads when the comments are in the viewport (using the Intersection Observer API).
 
 # h-card configuration
-# will identify you on the indieweb (see https://microformats.org/wiki/h-card)
+# Will identify you on the indieweb (see https://microformats.org/wiki/h-card)
 [extra.hcard]
-enable = true # Enables the h-card on the home page
-# with_mail = false # Add your email to the card if extra.email is set and not encoded
-with_social_links = true # Add your social links to the card
-# homepage = "https://myhomepage.net" # Homepage url, default to the value of 'base_url'
+# Enable home page h-card.
+enable = true
+# Add your email to the card if extra.email is set and not encoded.
+# with_mail = true
+# Add your social links ('socials' config) to the card.
+with_social_links = true
+# Homepage url. Defaults to the value of 'base_url'.
+# homepage = "https://myhomepage.net"
 # avatar = "img/profile.webp"
-# full_name = "John Doe" # Display name, default to the value of 'author'
-# biography = "Fond of the indieweb" # Small bio, as shown on social media profiles 
+# Display name, default to the value of 'author'.
+# full_name = "John Doe"
+# Small bio, as shown on social media profiles.
+# biography = "Fond of the indieweb"
 #
 # You can add any property from https://microformats.org/wiki/h-card#Properties
 # Make sure to replace all '-' characters by '_'
-# Below are some examples
+# Examples:
 # p_nickname = "nickname"
 # p_locality = "Bordeaux"
 # p_country_name = "France"

--- a/theme.toml
+++ b/theme.toml
@@ -375,3 +375,21 @@ custom_subset = true
 # voting = true
 # page_author_hashes = ""  # hash (or list of hashes) of the author.
 # lazy_loading = true  # Loads when the comments are in the viewport (using the Intersection Observer API).
+
+# h-card configuration
+# will identify you on the indieweb (see https://microformats.org/wiki/h-card)
+[extra.hcard]
+enable = true # Enables the h-card on the home page
+# with_mail = false # Add your email to the card if extra.email is set and not encoded
+with_social_links = true # Add your social links to the card
+# homepage = "https://myhomepage.net" # Homepage url, default to the value of 'base_url'
+# avatar = "img/profile.webp"
+# full_name = "John Doe" # Display name, default to the value of 'author'
+# biography = "Fond of the indieweb" # Small bio, as shown on social media profiles 
+#
+# You can add any property from https://microformats.org/wiki/h-card#Properties
+# Make sure to replace all '-' characters by '_'
+# Below are some examples
+# p_nickname = "nickname"
+# p_locality = "Bordeaux"
+# p_country_name = "France"


### PR DESCRIPTION
## Summary

This adds a minimal hidden h-card to the home page.

### Related issue

Discussed in #463

## Changes

The `templates\section.html` template includes a new partial `partials\hcard.html` which contains the h-card content.
The h-card stays hidden, so I kept the html minimal and I did not include any new css.

There is a new `[extra.hcard]` section at the end of the `theme.toml` and `config.toml` files.

I added a _Indieweb / Representative h-card_ paragraph at the end of the _Mastering tabi settings_ page.

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [x] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [x] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [x] I have updated `theme.toml` with a sane default for the feature
- [x] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [x] Updated `config.toml` comments
  - [x] Updated `theme.toml` comments
  - [x] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan

