### PR TITLE
🐛 fix: fix hcard html tags

### DIFF
--- a/templates/partials/hcard.html
+++ b/templates/partials/hcard.html
@@ -61,7 +61,7 @@
     {% if key not in ['enable', 'with_mail', 'with_social_links', 'homepage', 'full_name', 'avatar', 'biography', 'p_nickname'] %}
       {% if not dl_started %}
         <dl>
-        {% set dl_started = true %}
+        {% set_global dl_started = true %}
       {% endif %}
       <dt>{{ key | replace(from="p_", to="") | replace(from="u_", to="") | replace(from="dt_", to="") | replace(from="_", to=" ") | capitalize }}</dt>
       <dd class="{{ key | replace(from="_", to="-") }}">{{ value }}</dd>
@@ -70,4 +70,6 @@
   {% if dl_started %}
     </dl>
   {% endif %}
+
+  </div>
 {% endif %}


### PR DESCRIPTION
## Summary

This fixes missing  html closing tags in hcard template 

### Related issue

#507

## Changes

In partials/hcard.html:
- Add closing div tag
- replace `set` by `set_global` in for loop


### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [x ] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
