### PR TITLE
✨ feat: support dynamic light & dark favicons

### DIFF
--- a/static/js/faviconTheme.js
+++ b/static/js/faviconTheme.js
@@ -1,0 +1,28 @@
+// Get the light and dark favicon elements
+lightSchemeIcon = document.querySelector('link#light-favicon');
+darkSchemeIcon = document.querySelector('link#dark-favicon');
+
+// Set the favicon color by adding the appropriate link element
+// to the document head and removing the other
+function updateFaviconColor(dark) {
+    if (!lightSchemeIcon || !darkSchemeIcon) return;
+
+    if (dark) {
+        lightSchemeIcon.remove();
+        document.head.append(darkSchemeIcon);
+    } else {
+        document.head.append(lightSchemeIcon);
+        darkSchemeIcon.remove();
+    }
+}
+
+// Get the current theme at startup, defaulting to light
+const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
+
+// Set the favicon color on startup
+updateFaviconColor(currentTheme === 'dark');
+
+// Listen for theme changes and update the favicon color accordingly
+window.addEventListener('themeChanged', (event) => {
+    updateFaviconColor(event.detail.theme === 'dark');
+});

--- a/static/js/faviconTheme.js
+++ b/static/js/faviconTheme.js
@@ -16,8 +16,13 @@ function updateFaviconColor(dark) {
     }
 }
 
-// Get the current theme at startup, defaulting to light
-const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
+// Determine the initial theme.
+let currentTheme =
+    localStorage.getItem('theme') ||
+    document.documentElement.getAttribute('data-theme') ||
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
 
 // Set the favicon color on startup
 updateFaviconColor(currentTheme === 'dark');

--- a/static/js/faviconTheme.js
+++ b/static/js/faviconTheme.js
@@ -20,9 +20,7 @@ function updateFaviconColor(dark) {
 let currentTheme =
     localStorage.getItem('theme') ||
     document.documentElement.getAttribute('data-theme') ||
-    window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light';
+    (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
 
 // Set the favicon color on startup
 updateFaviconColor(currentTheme === 'dark');

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -14,6 +14,11 @@
     {# Favicon #}
     {% if config.extra.favicon %}
         <link rel="icon" type="image/png" href="{{ get_url(path=config.extra.favicon) }}"/>
+    {% elif config.extra.light_favicon and config.extra.dark_favicon %}
+        {# Favicon theme switcher. If JavaScript is disabled, defaults to the light icon #}
+        <link id="dark-favicon" rel="icon" href="{{ get_url(path=config.extra.dark_favicon) }}">
+        <link id="light-favicon" rel="icon" href="{{ get_url(path=config.extra.light_favicon) }}">
+        <script type="text/javascript" src="{{ get_url(path='js/faviconTheme.js') | safe }}"></script>
     {% endif %}
     {% if config.extra.favicon_emoji %}
         <link rel=icon href='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y="50%" x="50%" dominant-baseline="central" text-anchor="middle" font-size="88">{{ config.extra.favicon_emoji }}</text></svg>'>

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -16,8 +16,8 @@
         <link rel="icon" type="image/png" href="{{ get_url(path=config.extra.favicon) }}"/>
     {% elif config.extra.light_favicon and config.extra.dark_favicon %}
         {# Favicon theme switcher. If JavaScript is disabled, defaults to the light icon #}
-        <link id="dark-favicon" rel="icon" href="{{ get_url(path=config.extra.dark_favicon) }}">
-        <link id="light-favicon" rel="icon" href="{{ get_url(path=config.extra.light_favicon) }}">
+        <link id="dark-favicon" rel="icon" type="image/png" href="{{ get_url(path=config.extra.dark_favicon) }}">
+        <link id="light-favicon" rel="icon" type="image/png" href="{{ get_url(path=config.extra.light_favicon) }}">
         <script type="text/javascript" src="{{ get_url(path='js/faviconTheme.js') | safe }}"></script>
     {% endif %}
     {% if config.extra.favicon_emoji %}

--- a/theme.toml
+++ b/theme.toml
@@ -200,6 +200,11 @@ invert_title_order = false
 
 # Full path after the base URL required. So if you were to place it in "static" it would be "/favicon.ico"
 # favicon = ""
+# 
+# Or, you can set both light and dark favicons to be used depending on the theme.
+# The light favicon will be used if JavaScript is not enabled or on Safari.
+# light_favicon = ""
+# dark_favicon = ""
 
 # Add an emoji here to use it as favicon.
 # Compatibility: https://caniuse.com/link-icon-svg


### PR DESCRIPTION
## Summary

Updated the HTML header to support light & dark favicons.

## Changes

JavaScript is used to add/remove the link element from the document header. This is done on startup by using the same method as the theme switcher. A listener for theme changes updates the favicon too.

This approach seemed to be the most compatible with the current theme switching implementation. However, it does require JavaScript.

This works on chromium & gecko browsers, but not safari. I cannot find clear documentation, but it [seems like Safari does not support adding favicons to the document head](https://stackoverflow.com/a/66099108).

If the browser has JavaScript disabled, or if the browser is Safari, the light favicon icon will be used.

### Screenshots

To see it in action, [my personal website](https://camerontaylor.dev/) is currently using this branch of the theme.

<img width="1041" alt="image" src="https://github.com/user-attachments/assets/f472190f-519d-424f-b753-8bc92992f73d" />

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [x] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [x] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [ ] I have tested all possible scenarios for this change
- [x] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
