### PR TITLE
✨ feat(webmentions): use small hcard in post page

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -137,6 +137,10 @@ Current section extra: {% if current_section %}{{ current_section.extra | json_e
                 {%- set previous_visible = true -%}
             {% endif %}
 
+            {% if config.extra.hcard and config.extra.hcard.enable and ( not author_list or author_list is containing(config.author)) %}
+                {% include "partials/hcard_small.html" %}
+            {% endif %}
+
             {%- set separator_with_class = "<span class='separator' aria-hidden='true'>" ~ separator ~ "</span>"-%}
 
             {#- Date -#}

--- a/templates/partials/hcard.html
+++ b/templates/partials/hcard.html
@@ -16,7 +16,7 @@
     {%- if hcard.avatar -%}
     <img
       class="u-photo"
-      src="{{ get_url(path=hcard.avatar) }}"
+      src="{{ get_url(path=hcard.avatar, cachebust=true) }}"
       width="200"
       height="200"
       alt="{{ full_name }}"

--- a/templates/partials/hcard_small.html
+++ b/templates/partials/hcard_small.html
@@ -1,0 +1,26 @@
+{%- set hcard = config.extra.hcard -%}
+
+{%- set full_name = config.author -%}
+{%- if hcard.full_name -%}
+  {%- set full_name = hcard.full_name -%}
+{%- endif -%}
+
+{%- set homepage = config.base_url -%}
+{%- if hcard.homepage -%}
+  {%- set homepage = hcard.homepage -%}
+{%- endif -%}
+
+{%- set icon_attr = "" -%}
+{%- if hcard.avatar -%}
+    {%- set icon_attr = "author-icon" -%}
+{%- endif -%}
+
+<span class="hidden p-author h-card">
+<a rel="author" href="{{ homepage }}" class="u-url {{ icon_attr }}" title="{{ full_name }}">
+    {%- if hcard.avatar -%}
+    <img class="u-photo" src="{{ get_url(path=hcard.avatar) }}" alt="{{ full_name }}" />
+    {%- else -%}
+    {{ full_name }}
+    {%- endif -%}
+</a>
+</span>

--- a/templates/partials/hcard_small.html
+++ b/templates/partials/hcard_small.html
@@ -18,7 +18,7 @@
 <span class="hidden p-author h-card">
 <a rel="author" href="{{ homepage }}" class="u-url {{ icon_attr }}" title="{{ full_name }}">
     {%- if hcard.avatar -%}
-    <img class="u-photo" src="{{ get_url(path=hcard.avatar) }}" alt="{{ full_name }}" />
+    <img class="u-photo" src="{{ get_url(path=hcard.avatar, cachebust=true) }}" alt="{{ full_name }}" />
     {%- else -%}
     {{ full_name }}
     {%- endif -%}


### PR DESCRIPTION
## Summary

Add a small hcard to each post in order to add author name, avatar and homepage links when doing webmentions from articles. This is different from the  main  hcard of the homepage which has more information and is used for profile, but is not automatically fetched by webmentions parsers if the webmention link to another page 

### Related issue

#463

## Changes

- add the partial  `partials\hcard_small.html`
- include this partial in the page template `templates/page.html` if the `config.extra.hcard` is set and `config.extra.hcard.enable` is true. 


### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [x] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist


- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan