### PR TITLE
🐛 fix: allow feed icon to be hidden

### DIFF
--- a/templates/macros/feed_utils.html
+++ b/templates/macros/feed_utils.html
@@ -11,7 +11,7 @@
 
 {#- Check footer feed icon conditions -#}
 {%- macro should_show_footer_feed_icon() -%}
-    {%- set generate_feed = feed_utils::get_generate_feed() -%}
+    {%- set generate_feed = feed_utils::get_generate_feed() == "true" -%}
     {%- set feed_url = feed_utils::get_feed_url() -%}
     {{- generate_feed and config.extra.feed_icon and feed_url -}}
 {%- endmacro should_show_footer_feed_icon -%}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -6,7 +6,7 @@
 
 {#- Feed icon -#}
 {%- set feed_url = feed_utils::get_feed_url() -%}
-{%- set should_show_feed = feed_utils::should_show_footer_feed_icon() -%}
+{%- set should_show_feed = feed_utils::should_show_footer_feed_icon() == "true" -%}
 
 {%- set should_show_footer_icons = should_show_feed or config.extra.socials or config.extra.email -%}
 

--- a/templates/tags/single.html
+++ b/templates/tags/single.html
@@ -3,7 +3,7 @@
 {% block main_content %}
 
 {#- Feed icon -#}
-{%- set generate_feed = feed_utils::get_generate_feed() -%}
+{%- set generate_feed = feed_utils::get_generate_feed() == "true" -%}
 {%- set feed_url = feed_utils::get_feed_url() -%}
 {%- set feed_pre_conditions = generate_feed and feed_url and taxonomy.feed -%}
 {%- set show_feed_icon = feed_pre_conditions and term.pages | filter(attribute="date") -%}

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -3,7 +3,7 @@
 {% block main_content %}
 
 {#- Feed icon -#}
-{%- set generate_feed = feed_utils::get_generate_feed() -%}
+{%- set generate_feed = feed_utils::get_generate_feed() == "true" -%}
 {%- set feed_url = feed_utils::get_feed_url() -%}
 {%- set feed_pre_conditions = generate_feed and feed_url and taxonomy.feed -%}
 {%- set show_feed_icon = feed_pre_conditions and term.pages | filter(attribute="date") | length > 0 -%}


### PR DESCRIPTION
## Summary

Ensure correct boolean comparison for feed generation in `tera` templates 

### Related issue

#532 

## Changes

this is already implemented in other part of the code:
```
{% if macros_settings::evaluate_setting_priority(setting="quick_navigation_buttons", page=page_s, section=section_s, default_global_value=false) == "true" %}
```
in `templates/partials/extra_features.html`

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [ ] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
