### PR TITLE
✨ feat(analytics): make Umami DNT behavior configurable

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -372,6 +372,9 @@ service = "goatcounter"
 # Leave this field empty if you're using the service's default hosting.
 self_hosted_url = "https://tabi-stats.osc.garden"
 
+# Optional: For Umami, enable this option to respect users' Do Not Track (DNT) settings. The default is true.
+do_not_track = true
+
 # giscus support for comments. https://giscus.app
 # Setup instructions: https://welpo.github.io/tabi/blog/comments/#setup
 [extra.giscus]

--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuració de tabi: guia completa"
 date = 2023-09-18
-updated = 2025-06-08
+updated = 2025-06-16
 description = "Descobreix les múltiples maneres en què pots personalitzar tabi."
 
 [taxonomies]
@@ -801,6 +801,8 @@ Pots configurar-los en la secció `[extra.analytics]` del teu arxiu `config.toml
   - Per a GoatCounter: `"https://stats.example.com"`
   - Per a Umami: `"https://umami.example.com"`
   - Per a Plausible: `"https://plausible.example.com"`
+
+- `do_not_track`: (només per a Umami) opcional. Quan s'estableix com a `true`, es desactiva el seguiment per als usuaris els navegadors dels quals envien una capçalera "Do Not Track".
 
 Un exemple de configuració per a GoatCounter no auto-allotjada seria:
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuración de tabi: guía completa"
 date = 2023-09-18
-updated = 2025-06-08
+updated = 2025-06-16
 description = "Descubre las múltiples maneras en que puedes personalizar tabi."
 
 [taxonomies]
@@ -802,6 +802,8 @@ Puedes configurarlos en la sección `[extra.analytics]` de tu archivo `config.to
   - Para GoatCounter: `"https://stats.example.com"`
   - Para Umami: `"https://umami.example.com"`
   - Para Plausible: `"https://plausible.example.com"`
+
+- `do_not_track`: (sólo para Umami) opcional. Cuando se establece en `true`, se desactiva el seguimiento para los usuarios cuyos navegadores envían un encabezado "Do Not Track".
 
 Un ejemplo de configuración para GoatCounter no auto-alojada sería:
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -811,6 +811,8 @@ You can set them up in the `[extra.analytics]` section of your `config.toml`.
   - For Umami: `"https://umami.example.com"`
   - For Plausible: `"https://plausible.example.com"`
 
+- `do_not_track`: (Umami only) Optional. When set to `true`, the generated tracking script will include the `data-do-not-track="true"` attribute, which disables tracking for users whose browsers send a "Do Not Track" (DNT) header.
+
 An example configuration for non-self-hosted GoatCounter would look like this:
 
 ```toml

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Mastering tabi Settings: A Comprehensive Guide"
 date = 2023-09-18
-updated = 2025-06-08
+updated = 2025-06-16
 description = "Discover the many ways you can customise your tabi site."
 
 [taxonomies]
@@ -811,7 +811,7 @@ You can set them up in the `[extra.analytics]` section of your `config.toml`.
   - For Umami: `"https://umami.example.com"`
   - For Plausible: `"https://plausible.example.com"`
 
-- `do_not_track`: (Umami only) Optional. When set to `true`, the generated tracking script will include the `data-do-not-track="true"` attribute, which disables tracking for users whose browsers send a "Do Not Track" (DNT) header.
+- `do_not_track`: (Umami only) Optional. When set to `true`, the generated tracking script will include the `data-do-not-track="true"` attribute, which disables tracking for users whose browsers send a "Do Not Track" header.
 
 An example configuration for non-self-hosted GoatCounter would look like this:
 

--- a/templates/partials/analytics.html
+++ b/templates/partials/analytics.html
@@ -25,7 +25,7 @@
         data-website-id="{{ analytics_id }}"
         src="https://cloud.umami.is/script.js"
     {% endif %}
-    data-do-not-track="true">
+    {% if config.extra.analytics.do_not_track %}data-do-not-track="true"{% endif %}>
     </script>
 
     {% elif analytics_service == "plausible" %}

--- a/theme.toml
+++ b/theme.toml
@@ -320,6 +320,9 @@ custom_subset = true
 # Leave this field empty if you're using the service's default hosting.
 # self_hosted_url = ""
 
+# Optional: For Umami, enable this option to respect users' Do Not Track (DNT) settings. The default is true.
+do_not_track = true
+
 # giscus support for comments. https://giscus.app
 # Setup instructions: https://welpo.github.io/tabi/blog/comments/#setup
 [extra.giscus]


### PR DESCRIPTION
## Summary

Adds support for an optional `do_not_track = true` setting under `[extra.analytics]` to control whether Umami respects the browser’s Do Not Track (DNT) header.

This change makes the behavior configurable and consistent with other analytics services, which typically do not default to honoring DNT.

### Related issue

Closes #535 

## Changes

- Added conditional output of `data-do-not-track="true"` in the Umami script tag
- Introduced `do_not_track` option in `[extra.analytics]` in `config.toml`
- Updated `theme.toml` with a representative key and example
- Documented the new setting in the English version of the "Analytics" configuration page

Only the English documentation has been updated due to my language limitations.

### Accessibility

Not applicable. This change does not affect the frontend UI or accessibility.

### Screenshots

Not applicable.

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [x] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [x] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [x] I have updated `theme.toml` with a sane default for the feature
- [x] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [x] I have made corresponding changes to the documentation:
  - [x] Updated `config.toml` comments
  - [x] Updated `theme.toml` comments
  - [x] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
