### PR TITLE
♻️ refactor: force a trailing slash on the nav home title

### DIFF
--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -1,7 +1,7 @@
 <header>
     <nav class="navbar">
         <div class="nav-title">
-            <a class="home-title" href="{{ get_url(path='/', lang=lang, trailing_slash=true) }}">{{ config.title }}</a>
+            <a class="home-title" href="{{ get_url(path='/', lang=lang, trailing_slash=(lang == config.default_language)) }}">{{ config.title }}</a>
         </div>
 
         {%- if config.extra.menu %}

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -1,7 +1,7 @@
 <header>
     <nav class="navbar">
         <div class="nav-title">
-            <a class="home-title" href="{{ get_url(path='/', lang=lang) }}">{{ config.title }}</a>
+            <a class="home-title" href="{{ get_url(path='/', lang=lang, trailing_slash=true) }}">{{ config.title }}</a>
         </div>
 
         {%- if config.extra.menu %}


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Provide a trailing slash on the home navigation link to work if the `base_url` is set to a `/` only because in this case the home-link does not work.

### Related issue

#546

## Changes

use the additional parameter `trailing_slash` from the `get_url` function


### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)


