### PR TITLE
♻️ refactor: prevent HTML escaping of joined CSP strings

### DIFF
--- a/templates/partials/content_security_policy.html
+++ b/templates/partials/content_security_policy.html
@@ -74,19 +74,19 @@ content="default-src 'self'
 
     {%- for domain in config.extra.allowed_domains -%}
         {%- if domain.directive == "connect-src" -%}
-            {%- set configured_connect_src = domain.domains | join(sep=' ') -%}
+            {%- set configured_connect_src = domain.domains | join(sep=' ') | safe -%}
             {%- set_global connect_src = connect_src ~ " " ~ configured_connect_src  -%}
             {%- continue -%}
         {%- endif -%}
 
         {%- if domain.directive == "script-src" -%}
-            {%- set configured_script_src = domain.domains | join(sep=' ') -%}
+            {%- set configured_script_src = domain.domains | join(sep=' ') | safe -%}
             {%- set_global script_src = script_src ~ " " ~ configured_script_src  -%}
             {%- continue -%}
         {%- endif -%}
 
         {#- Handle directives that are not connect-src -#}
-        {{ domain.directive }} {{ domain.domains | join(sep=' ') -}}
+        {{ domain.directive }} {{ domain.domains | join(sep=' ') | safe -}}
 
         {%- if domain.directive == "style-src" -%}
             {%- if utterances_enabled or hyvortalk_enabled or mermaid_enabled %} 'unsafe-inline'


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

This corrects the CSP header as to not escape the HTML. When using Tera `join`, the original resulted in the following (on a fresh tabi install with no optional features enabled):

```html
<meta http-equiv="Content-Security-Policy" content="default-src 'self';font-src &#x27;self&#x27; data:;img-src &#x27;self&#x27; https:&#x2F;&#x2F;* data:;media-src &#x27;self&#x27;;style-src &#x27;self&#x27;;frame-src player.vimeo.com https:&#x2F;&#x2F;www.youtube-nocookie.com;connect-src 'self' ws:;script-src 'self' 'self'">
```

This change corrects the above to be:

```html
<meta http-equiv="Content-Security-Policy" content="default-src 'self';font-src 'self' data:;img-src 'self' https://* data:;media-src 'self';style-src 'self';frame-src player.vimeo.com https://www.youtube-nocookie.com;connect-src 'self' ws:;script-src 'self' 'self'">
```

### Related issue

<!-- Mention any relevant issues like #123 -->

## Changes

<!-- Please provide some more detail regarding the changes.
Add any additional information, configuration, or data that might be necessary for the review -->

### Accessibility

<!-- Have you taken steps to make your changes accessible? This could include:
- Semantic HTML
- ARIA attributes
- Keyboard navigation
- Voiceover or screen reader compatibility
- Colour contrast
Please elaborate on the actions taken.
If you need help, please ask! -->

### Screenshots

<!-- If applicable, add screenshots to help explain the changes made. Consider if a before/after is helpful -->

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [ ] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
