### PR TITLE
✨ feat: add per-language date format configuration

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -235,6 +235,13 @@ long_date_format = "%d %B %Y"
 # Default is "6th July 2049" in English and "%-d %B %Y" in other languages.
 short_date_format = ""
 
+# Per-language date format overrides.
+# Examples: Spanish uses "3 de febrero de 2024", German uses "3. Februar 2024"
+date_formats = [
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
+    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+]
+
 # Custom separator used in title tag and posts metadata (between date, time to read, and tags).
 separator = "•"
 

--- a/content/blog/faq-languages/index.ca.md
+++ b/content/blog/faq-languages/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Lost in Translation? Explora les capacitats multilingües de tabi"
 date = 2023-09-12
-updated = 2025-04-02
+updated = 2025-08-06
 description = "Descobreix com tabi t'ajuda a connectar amb una audiència global gràcies a les seves funcions multilingües. Aprèn a canviar la llengua per defecte, afegir més llengües i aportar les teves pròpies traduccions."
 
 [taxonomies]
@@ -106,6 +106,19 @@ tabi cerca els fitxers de cadenes en el següent ordre. `$base_directory` és on
 Per tant, si crees `i18n/ca.toml` al teu directori base, tabi llegirà les cadenes de text d'aquest fitxer en lloc de les cadenes predeterminades en català. Pots fer això per a qualsevol idioma, suportat o no.
 
 Assegura't de copiar tot el fitxer per a aquest idioma primer, o el tema utilitzarà l'anglès per les claus que faltin.
+
+## Com personalitzo els formats de data per a diferents idiomes?
+
+Pots establir formats de data específics per idioma al teu `config.toml` utilitzant la matriu `date_formats`:
+
+```toml
+date_formats = [
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
+    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+]
+```
+
+Això permet que cada idioma mostri les dates segons les convencions locals. Per exemple, l'espanyol mostrarà «3 de febrero de 2024» mentre que l'alemany mostrarà «3. Februar 2024». Si no es defineix un format específic per a un idioma, tabi utilitzarà la configuració global `long_date_format` i `short_date_format`.
 
 ## Què passa si falta una traducció o està incompleta?
 

--- a/content/blog/faq-languages/index.es.md
+++ b/content/blog/faq-languages/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "¿Lost in Translation? Explora las capacidades multilingües de tabi"
 date = 2023-09-12
-updated = 2025-04-02
+updated = 2025-08-06
 description = "Descubre cómo tabi te ayuda a conectar con una audiencia global gracias a sus funciones multilingües. Aprende a cambiar el idioma por defecto, añadir más idiomas y aportar tus propias traducciones."
 
 [taxonomies]
@@ -106,6 +106,19 @@ tabi busca los archivos de cadenas en el siguiente orden. `$base_directory` es d
 Por lo tanto, si creas `i18n/en.toml` en tu directorio base, tabi leerá las cadenas de texto de ese archivo en lugar de las cadenas predeterminadas en inglés. Puedes hacer esto para cualquier idioma, soportado o no.
 
 Asegúrate de copiar todo el archivo para ese idioma primero, o el tema usará el inglés para las claves faltantes.
+
+## ¿Cómo personalizo los formatos de fecha para diferentes idiomas?
+
+Puedes establecer formatos de fecha específicos por idioma en tu `config.toml` usando la matriz `date_formats`:
+
+```toml
+date_formats = [
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
+    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+]
+```
+
+Esto permite que cada idioma muestre las fechas según las convenciones locales. Por ejemplo, el español mostrará «3 de febrero de 2024» mientras que el alemán mostrará «3. Februar 2024». Si no se define un formato específico para un idioma, tabi usará la configuración global `long_date_format` y `short_date_format`.
 
 ## ¿Qué pasa si falta una traducción o está incompleta?
 

--- a/content/blog/faq-languages/index.md
+++ b/content/blog/faq-languages/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Lost in Translation? Not with tabi's Multilingual Capabilities"
 date = 2023-09-12
-updated = 2025-04-02
+updated = 2025-08-06
 description = "Master the art of serving a global audience through tabi's built-in multilingual features. Learn how to change the default language, add multilingual support, and contribute your own translations."
 
 [taxonomies]
@@ -107,6 +107,19 @@ tabi looks for the strings files in the following order. `$base_directory` is wh
 So if you create  `i18n/en.toml` in your base directory, tabi will read the strings from that file instead of the default English strings. You can do this for any language, supported or not.
 
 Make sure to copy the entire file for that language first, or the theme will fall back to the default English strings.
+
+## How do I customize date formats for different languages?
+
+You can set language-specific date formats in your `config.toml` using the `date_formats` array:
+
+```toml
+date_formats = [
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
+    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+]
+```
+
+This allows each language to display dates according to local conventions. For example, Spanish will show "3 de febrero de 2024" while German will show "3. Februar 2024". If no language-specific format is defined, tabi will use the global `long_date_format` and `short_date_format` settings.
 
 ## What happens if a translation is missing or incomplete?
 

--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuració de tabi: guia completa"
 date = 2023-09-18
-updated = 2025-08-01
+updated = 2025-08-06
 description = "Descobreix les múltiples maneres en què pots personalitzar tabi."
 
 [taxonomies]
@@ -973,6 +973,19 @@ tabi té dos formats de data: `long_date_format` i `short_date_format`. El forma
 Per defecte és "6th July 2049" per a ambdós formats en anglès. Per a altres idiomes, el predeterminat és `"%d %B %Y"` per al format llarg i `"%-d %b %Y"` per al format curt.
 
 A Zola, la sintaxi per al format de temps està inspirada en strftime. Una referència completa està disponible a la [documentació de chrono](https://docs.rs/chrono/0.4.31/chrono/format/strftime/index.html).
+
+#### Formats de data per idioma
+
+Pots personalitzar els formats de data per idiomes específics utilitzant la matriu `date_formats` a `config.toml`:
+
+```toml
+date_formats = [
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
+    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+]
+```
+
+Això permet que diferents idiomes utilitzin formats de data culturalment apropiats (per exemple, "6. Juli 2049" per a alemany VS "6 de julio de 2049" per a espanyol).
 
 ### Separador personalitzat
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuración de tabi: guía completa"
 date = 2023-09-18
-updated = 2025-08-01
+updated = 2025-08-06
 description = "Descubre las múltiples maneras en que puedes personalizar tabi."
 
 [taxonomies]
@@ -978,6 +978,19 @@ tabi tiene dos formatos de fecha: `long_date_format` y `short_date_format`. El f
 Por defecto es "6th July 2049" para ambos formatos en inglés. Para otros idiomas, el predeterminado es `"%d %B %Y"` para el formato largo y `"%-d %b %Y"` para el formato corto.
 
 En Zola, la sintaxis para el formateo de tiempo está inspirada en strftime. Una referencia completa está disponible en la [documentación de chrono](https://docs.rs/chrono/0.4.31/chrono/format/strftime/index.html).
+
+#### Formatos de fecha por idioma
+
+Puedes personalizar los formatos de fecha para idiomas específicos usando la matriz `date_formats` en `config.toml`:
+
+```toml
+date_formats = [
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
+    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+]
+```
+
+Esto permite que diferentes idiomas usen formatos de fecha culturalmente apropiados (por ejemplo, "6 de julio de 2049" en español o "6. Juli 2049" en alemán).
 
 ### Separador personalizado
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Mastering tabi Settings: A Comprehensive Guide"
 date = 2023-09-18
-updated = 2025-08-01
+updated = 2025-08-06
 description = "Discover the many ways you can customise your tabi site."
 
 [taxonomies]
@@ -988,6 +988,19 @@ tabi has two date formats: `long_date_format` and `short_date_format`. The short
 The default is "6th July 2049" for both formats in English. For other languages, the defaut is `"%d %B %Y"` for the long format and `"%-d %b %Y"` for the short format.
 
 In Zola, time formatting syntax is inspired fom strftime. A full reference is available in the [chrono docs](https://docs.rs/chrono/0.4.31/chrono/format/strftime/index.html).
+
+#### Per-language date formats
+
+You can customise date formats for specific languages using the `date_formats` array in `config.toml`:
+
+```toml
+date_formats = [
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
+    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+]
+```
+
+This allows different languages to use culturally appropriate date formatting (e.g. Spanish "3 de febrero de 2024" vs German "3. Februar 2024").
 
 ### Custom Separator
 

--- a/templates/macros/format_date.html
+++ b/templates/macros/format_date.html
@@ -3,7 +3,23 @@
 {#- Set locale -#}
 {%- set date_locale = macros_translate::translate(key="date_locale", default="en_GB", language_strings=language_strings) -%}
 
-{%- if config.extra.short_date_format and short -%}
+{#- Check for language-specific date formats -#}
+{%- set language_format = "" -%}
+{%- if config.extra.date_formats -%}
+    {%- for format_config in config.extra.date_formats -%}
+        {%- if format_config.lang == lang -%}
+            {%- if short and format_config.short -%}
+                {%- set_global language_format = format_config.short -%}
+            {%- elif not short and format_config.long -%}
+                {%- set_global language_format = format_config.long -%}
+            {%- endif -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endif -%}
+
+{%- if language_format -%}
+    {{ date | date(format=language_format, locale=date_locale) }}
+{%- elif config.extra.short_date_format and short -%}
     {{ date | date(format=config.extra.short_date_format, locale=date_locale) }}
 {%- elif config.extra.long_date_format and not short -%}
     {{ date | date(format=config.extra.long_date_format, locale=date_locale) }}

--- a/theme.toml
+++ b/theme.toml
@@ -183,6 +183,13 @@ quick_navigation_buttons = false
 # Default is "6th July 2049" in English and "%-d %B %Y" in other languages.
 short_date_format = ""
 
+# Per-language date format overrides.
+# Examples: Spanish uses "3 de febrero de 2024", German uses "3. Februar 2024"
+# date_formats = [
+#     { lang = "es", long = "%d de %B de %Y", short = "%d %b %Y" },
+#     { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+# ]
+
 # Custom separator used in title tag and posts metadata (between date, time to read, and tags).
 separator = "•"
 


### PR DESCRIPTION
## Summary

Implement per-language date format customisation. Now you can specify different date formats for each language:

```toml
# Per-language date format overrides.
# Examples: Spanish uses "3 de febrero de 2024", German uses "3. Februar 2024"
date_formats = [
    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
]
```

### Related issue

Resolves #555

## Changes

Added support for language-specific date formats through a new `date_formats` configuration option in `config.toml`. Users can now customize both long and short date formats per language to match local conventions (e.g. American English "Feb 3, 2024" vs Spanish "3 de febrero de 2024").

**Modified files:**

- `templates/macros/format_date.html` - Enhanced macro to check for language-specific formats first, with fallback to global settings
- `config.toml` - Added example `date_formats` array with Spanish and German examples
- `theme.toml` - Added commented configuration examples for reference

### Accessibility

N/A.

### Type of change

- [ ] Bug fix (fixes an issue without altering functionality)
- [x] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [x] I have updated `theme.toml` with a sane default for the feature
- [x] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [x] I have made corresponding changes to the documentation:
  - [x] Updated `config.toml` comments
  - [x] Updated `theme.toml` comments
  - [x] Updated "Mastering tabi" post in English
  - [x] (Optional) Updated "Mastering tabi" post in Spanish
  - [x] (Optional) Updated "Mastering tabi" post in Catalan