### PR TITLE
✨ feat: allow custom archive date format

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -235,11 +235,15 @@ long_date_format = "%d %B %Y"
 # Default is "6th July 2049" in English and "%-d %B %Y" in other languages.
 short_date_format = ""
 
+# Date format used for the archive page.
+# Default is "06 July" in English and "%d %b" in other languages.
+archive_date_format = ""
+
 # Per-language date format overrides.
 # Examples: Spanish uses "3 de febrero de 2024", German uses "3. Februar 2024"
 date_formats = [
-    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
-    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y", archive = "%d de %b" },
+    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y", archive = "%d. %b" },
 ]
 
 # Custom separator used in title tag and posts metadata (between date, time to read, and tags).

--- a/config.toml
+++ b/config.toml
@@ -242,7 +242,7 @@ archive_date_format = ""
 # Per-language date format overrides.
 # Examples: Spanish uses "3 de febrero de 2024", German uses "3. Februar 2024"
 date_formats = [
-    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y", archive = "%d de %b" },
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
     { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y", archive = "%d. %b" },
 ]
 

--- a/content/blog/faq-languages/index.ca.md
+++ b/content/blog/faq-languages/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Lost in Translation? Explora les capacitats multilingües de tabi"
 date = 2023-09-12
-updated = 2025-08-06
+updated = 2025-08-07
 description = "Descobreix com tabi t'ajuda a connectar amb una audiència global gràcies a les seves funcions multilingües. Aprèn a canviar la llengua per defecte, afegir més llengües i aportar les teves pròpies traduccions."
 
 [taxonomies]
@@ -113,12 +113,12 @@ Pots establir formats de data específics per idioma al teu `config.toml` utilit
 
 ```toml
 date_formats = [
-    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
-    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y", archive = "%d de %b" },
+    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y", archive = "%d. %b" },
 ]
 ```
 
-Això permet que cada idioma mostri les dates segons les convencions locals. Per exemple, l'espanyol mostrarà «3 de febrero de 2024» mentre que l'alemany mostrarà «3. Februar 2024». Si no es defineix un format específic per a un idioma, tabi utilitzarà la configuració global `long_date_format` i `short_date_format`.
+Això permet que cada idioma mostri les dates segons les convencions locals. Per exemple, l'espanyol mostrarà «3 de febrero de 2024» mentre que l'alemany mostrarà «3. Februar 2024». Si no es defineix un format específic per a un idioma, tabi utilitzarà la configuració global `long_date_format`, `short_date_format` i `archive_date_format`.
 
 ## Què passa si falta una traducció o està incompleta?
 

--- a/content/blog/faq-languages/index.es.md
+++ b/content/blog/faq-languages/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "¿Lost in Translation? Explora las capacidades multilingües de tabi"
 date = 2023-09-12
-updated = 2025-08-06
+updated = 2025-08-07
 description = "Descubre cómo tabi te ayuda a conectar con una audiencia global gracias a sus funciones multilingües. Aprende a cambiar el idioma por defecto, añadir más idiomas y aportar tus propias traducciones."
 
 [taxonomies]
@@ -113,12 +113,12 @@ Puedes establecer formatos de fecha específicos por idioma en tu `config.toml` 
 
 ```toml
 date_formats = [
-    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
-    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y", archive = "%d de %b" },
+    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y", archive = "%d. %b" },
 ]
 ```
 
-Esto permite que cada idioma muestre las fechas según las convenciones locales. Por ejemplo, el español mostrará «3 de febrero de 2024» mientras que el alemán mostrará «3. Februar 2024». Si no se define un formato específico para un idioma, tabi usará la configuración global `long_date_format` y `short_date_format`.
+Esto permite que cada idioma muestre las fechas según las convenciones locales. Por ejemplo, el español mostrará «3 de febrero de 2024» mientras que el alemán mostrará «3. Februar 2024». Si no se define un formato específico para un idioma, tabi usará la configuración global `long_date_format`, `short_date_format` y `archive_date_format`.
 
 ## ¿Qué pasa si falta una traducción o está incompleta?
 

--- a/content/blog/faq-languages/index.md
+++ b/content/blog/faq-languages/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Lost in Translation? Not with tabi's Multilingual Capabilities"
 date = 2023-09-12
-updated = 2025-08-06
+updated = 2025-08-07
 description = "Master the art of serving a global audience through tabi's built-in multilingual features. Learn how to change the default language, add multilingual support, and contribute your own translations."
 
 [taxonomies]
@@ -114,12 +114,12 @@ You can set language-specific date formats in your `config.toml` using the `date
 
 ```toml
 date_formats = [
-    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
-    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y", archive = "%d de %b" },
+    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y", archive = "%d. %b" },
 ]
 ```
 
-This allows each language to display dates according to local conventions. For example, Spanish will show "3 de febrero de 2024" while German will show "3. Februar 2024". If no language-specific format is defined, tabi will use the global `long_date_format` and `short_date_format` settings.
+This allows each language to display dates according to local conventions. For example, Spanish will show "3 de febrero de 2024" while German will show "3. Februar 2024". If no language-specific format is defined, tabi will use the global `long_date_format`, `short_date_format` and `archive_date_format` settings.
 
 ## What happens if a translation is missing or incomplete?
 

--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuració de tabi: guia completa"
 date = 2023-09-18
-updated = 2025-08-06
+updated = 2025-08-07
 description = "Descobreix les múltiples maneres en què pots personalitzar tabi."
 
 [taxonomies]
@@ -968,9 +968,9 @@ Per defecte, la data es mostra sota el títol de la publicació. Pots amagar-la 
 |:------:|:-------:|:-------------:|:---------------------:|:-------------------:|
 |   ❌   |   ❌    |      ✅       |          ❌           |         ❌          |
 
-tabi té dos formats de data: `long_date_format` i `short_date_format`. El format curt s'utilitza a les metadades d'una publicació, mentre que el format llarg s'utilitza al llistar les publicacions (és a dir, a la [secció de blog](/ca/blog/) o a la [pàgina principal](/ca/)).
+tabi té tres formats de data: `long_date_format`, `short_date_format` i `archive_data_format`. El format curt s'utilitza a les metadades d'una publicació, mentre que el format llarg s'utilitza al llistar les publicacions (és a dir, a la [secció de blog](/ca/blog/) o a la [pàgina principal](/ca/)). El format d'arxiu s'utilitza per mostrar el dia i el mes a la pàgina d'arxiu.
 
-Per defecte és "6th July 2049" per a ambdós formats en anglès. Per a altres idiomes, el predeterminat és `"%d %B %Y"` per al format llarg i `"%-d %b %Y"` per al format curt.
+Per defecte és "6th July 2049" per als formats curt i llarg en anglès. Per a altres idiomes, el predeterminat és `"%d %B %Y"` per al format llarg i `"%-d %b %Y"` per al format curt. El format d'arxiu predeterminat universal és `"%d %b"`.
 
 A Zola, la sintaxi per al format de temps està inspirada en strftime. Una referència completa està disponible a la [documentació de chrono](https://docs.rs/chrono/0.4.31/chrono/format/strftime/index.html).
 
@@ -980,8 +980,8 @@ Pots personalitzar els formats de data per idiomes específics utilitzant la mat
 
 ```toml
 date_formats = [
-    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
-    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y", archive = "%d de %b" },
+    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y", archive = "%d. %b" },
 ]
 ```
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuración de tabi: guía completa"
 date = 2023-09-18
-updated = 2025-08-06
+updated = 2025-08-07
 description = "Descubre las múltiples maneras en que puedes personalizar tabi."
 
 [taxonomies]
@@ -973,9 +973,9 @@ Por defecto, la fecha se muestra debajo del título de la publicación. Puedes o
 |:------:|:-------:|:-------------:|:------------------:|:-------------------:|
 |   ❌   |   ❌    |      ✅       |         ❌         |         ❌          |
 
-tabi tiene dos formatos de fecha: `long_date_format` y `short_date_format`. El formato corto se utiliza en los metadatos de una publicación, mientras que el formato largo se utiliza al listar las publicaciones (es decir, en la [sección de blog](/es/blog/) o en la [página principal](/es/)).
+tabi tiene tres formatos de fecha: `long_date_format`, `short_date_format` y `archive_date_format`. El formato corto se utiliza en los metadatos de una publicación, mientras que el formato largo se utiliza al listar las publicaciones (es decir, en la [sección de blog](/es/blog/) o en la [página principal](/es/)). El formato de archivo se usa para mostrar el día y el mes en la página de archivo.
 
-Por defecto es "6th July 2049" para ambos formatos en inglés. Para otros idiomas, el predeterminado es `"%d %B %Y"` para el formato largo y `"%-d %b %Y"` para el formato corto.
+Por defecto es "6th July 2049" para los formatos corto y largo en inglés. Para otros idiomas, el predeterminado es `"%d %B %Y"` para el formato largo y `"%-d %b %Y"` para el formato corto. El formato de archivo predeterminado universal es `"%d %b"`.
 
 En Zola, la sintaxis para el formateo de tiempo está inspirada en strftime. Una referencia completa está disponible en la [documentación de chrono](https://docs.rs/chrono/0.4.31/chrono/format/strftime/index.html).
 
@@ -985,8 +985,8 @@ Puedes personalizar los formatos de fecha para idiomas específicos usando la ma
 
 ```toml
 date_formats = [
-    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
-    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y", archive = "%d de %b" },
+    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y", archive = "%d. %b" },
 ]
 ```
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Mastering tabi Settings: A Comprehensive Guide"
 date = 2023-09-18
-updated = 2025-08-06
+updated = 2025-08-07
 description = "Discover the many ways you can customise your tabi site."
 
 [taxonomies]
@@ -983,9 +983,9 @@ By default, the date is shown below the post title. You can hide it with `show_d
 |:----:|:-------:|:-------------:|:-----------------:|:-------------------:|
 |  ❌  |   ❌    |      ✅       |         ❌        |         ❌          |
 
-tabi has two date formats: `long_date_format` and `short_date_format`. The short format is used in a post's metadata, while the long format is used when listing posts (i.e. on the [blog section](@/blog/_index.md) or the [main page](@/_index.md)).
+tabi has three date formats: `long_date_format`, `short_date_format` and `archive_date_format`. The short format is used in a post's metadata, while the long format is used when listing posts (i.e. on the [blog section](@/blog/_index.md) or the [main page](@/_index.md)). The archive format is used to display day and month on the archive page.
 
-The default is "6th July 2049" for both formats in English. For other languages, the defaut is `"%d %B %Y"` for the long format and `"%-d %b %Y"` for the short format.
+The default is "6th July 2049" for `long_date_format` and `short_date_format` in English. For other languages, the defaut is `"%d %B %Y"` for the long format and `"%-d %b %Y"` for the short format. The universal default for the archive format is `"%d %b"`.
 
 In Zola, time formatting syntax is inspired fom strftime. A full reference is available in the [chrono docs](https://docs.rs/chrono/0.4.31/chrono/format/strftime/index.html).
 
@@ -995,8 +995,8 @@ You can customise date formats for specific languages using the `date_formats` a
 
 ```toml
 date_formats = [
-    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y" },
-    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y" },
+    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y", archive = "%d de %b" },
+    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y", archive = "%d. %b" },
 ]
 ```
 

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -7,6 +7,18 @@
 {# Set locale for date #}
 {% set date_locale = macros_translate::translate(key="date_locale", default="en_GB", language_strings=language_strings) %}
 
+{#- Check for language-specific date formats -#}
+{%- set language_format = "" -%}
+{%- if config.extra.date_formats -%}
+    {%- for format_config in config.extra.date_formats -%}
+        {%- if format_config.lang == lang -%}
+            {%- if format_config.archive -%}
+                {%- set_global language_format = format_config.archive -%}
+            {%- endif -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endif -%}
+
 <div class="archive">
     <ul class="list-with-title">
         {%- set source_paths = section.extra.section_path | default(value="blog/") -%}
@@ -55,7 +67,11 @@
                     <li class="listing-item">
                         <div class="post-time">
                             <span class="date">
-                                {{ post.date | date(format="%d %b", locale=date_locale) }}
+                                {%- if language_format -%}
+                                    {{ post.date | date(format=language_format, locale=date_locale) }}
+                                {%- else -%}
+                                    {{ post.date | date(format="%d %b", locale=date_locale) }}
+                                {%- endif -%}
                             </span>
                         </div>
                         <a href="{{ post.permalink }}" title="{{ post.title }}">{{ post.title | markdown(inline=true) | safe }}</a>

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -69,6 +69,8 @@
                             <span class="date">
                                 {%- if language_format -%}
                                     {{ post.date | date(format=language_format, locale=date_locale) }}
+                                {%- elif config.extra.archive_date_format -%}
+                                    {{ post.date | date(format=config.extra.archive_date_format, locale=date_locale) }}
                                 {%- else -%}
                                     {{ post.date | date(format="%d %b", locale=date_locale) }}
                                 {%- endif -%}

--- a/theme.toml
+++ b/theme.toml
@@ -183,6 +183,10 @@ quick_navigation_buttons = false
 # Default is "6th July 2049" in English and "%-d %B %Y" in other languages.
 short_date_format = ""
 
+# Date format used for the archive page.
+# Default is "06 July" in English and "%d %b" in other languages.
+# archive_date_format = ""
+
 # Per-language date format overrides.
 # Examples: Spanish uses "3 de febrero de 2024", German uses "3. Februar 2024"
 # date_formats = [


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

<!-- Please provide a brief description of the changes made in this PR -->

Implement per-language and universal date formatting for the archive page. The archive date format can be specified universally:

```toml
[extra]
# Date format used for the archive page.
# Default is "06 July" in English and "%d %b" in other languages.
archive_date_format = "%b %-d"
```

And it can also be specified per-language:
```toml
[extra]
# Per-language date format overrides.
# Examples: Spanish uses "3 de febrero de 2024", German uses "3. Februar 2024"
date_formats = [
    { lang = "es", long = "%d de %B de %Y", short = "%-d %b %Y", archive = "%d de %b" },
    { lang = "de", long = "%d. %B %Y", short = "%d.%m.%Y", archive = "%d. %b" },
]
```

### Related issue

<!-- Mention any relevant issues like #123 -->
Further resolves #555 

## Changes

<!-- Please provide some more detail regarding the changes.
Add any additional information, configuration, or data that might be necessary for the review -->
Added support for a universal and language-specific archive date formats through a new `archive_date_format` configuration option and an extension to the `date_formats` configuration option in `config.toml`. Users can now customize the archive date format (day and month) per language to match local conventions (e.g. American English "Feb 3" vs Spanish "3 de febrero").

**Modified files:**

* `templates/archive.html` - Enhanced template to check for a language-specific format first, with fallback to the universal setting
* `config.toml` - Added `archive_date_format` example and extended example `date_formats` array with Spanish and German examples
* `theme.toml` - Added and extended commented configuration examples for reference

### Accessibility

<!-- Have you taken steps to make your changes accessible? This could include:
- Semantic HTML
- ARIA attributes
- Keyboard navigation
- Voiceover or screen reader compatibility
- Colour contrast
Please elaborate on the actions taken.
If you need help, please ask! -->

N/A

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [x] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [x] I have updated `theme.toml` with a sane default for the feature
- [x] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [x] I have made corresponding changes to the documentation:
  - [x] Updated `config.toml` comments
  - [x] Updated `theme.toml` comments
  - [x] Updated "Mastering tabi" post in English
  - [x] (Optional) Updated "Mastering tabi" post in Spanish
  - [x] (Optional) Updated "Mastering tabi" post in Catalan
