### PR TITLE
✨ feat(i18n): display lcode in language switcher

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -184,6 +184,9 @@ iine_unified_languages = true
 # Can be set at section levels, following the hierarchy: section > config. See: https://welpo.github.io/tabi/blog/mastering-tabi-settings/#settings-hierarchy
 post_listing_index_reversed = false  # Defaults to false.
 
+# Show current language code on the language switcher
+language_switcher_show_lcode = false # Defaults to false
+
 # DEPRECATED!
 # Use Zola's built-in `bottom_footnotes = true` in the [markdown] section instead. (Available since v0.19.0)
 # Adds backlinks to footnotes (loads ~500 bytes of JavaScripts).

--- a/content/blog/faq-languages/index.md
+++ b/content/blog/faq-languages/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Lost in Translation? Not with tabi's Multilingual Capabilities"
 date = 2023-09-12
-updated = 2025-08-07
+updated = 2025-08-24
 description = "Master the art of serving a global audience through tabi's built-in multilingual features. Learn how to change the default language, add multilingual support, and contribute your own translations."
 
 [taxonomies]
@@ -148,3 +148,7 @@ If you did, you will need to manually update the translations. You can do this b
 ## Does tabi translate my content?
 
 No. tabi only translates the theme's text strings. You will need to translate your content yourself.
+
+# How to show current language code on the language switcher?
+
+Add `language_switcher_show_lcode = true` in your config extras.

--- a/sass/parts/_header.scss
+++ b/sass/parts/_header.scss
@@ -125,6 +125,31 @@ header {
             background: var(--meta-color);
         }
     }
+
+    .language-switcher-icon-with-code {
+        width: 0.7rem;
+        height: 0.7rem;
+        margin-right: 0.3rem;
+    }
+}
+
+.language-switcher-icon-code {
+    z-index: 10;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: -0.15rem;
+    color: var(--text-color);
+    font-weight: bold;
+    left: 0.6rem;
+    &:hover {
+        color: var(--meta-color);
+    }
+    font-size: 0.5rem;
+}
+
+.language-switcher-selected-item {
+    font-weight: bold;
 }
 
 .dropdown {

--- a/templates/partials/language_switcher.html
+++ b/templates/partials/language_switcher.html
@@ -1,7 +1,12 @@
 <li class="language-switcher">
     <details class="dropdown">
         <summary role="button" aria-haspopup="true" title="{{ macros_translate::translate(key="language_selection", default="Language selection", language_strings=language_strings) }}" aria-label="{{ macros_translate::translate(key="language_selection", default="Language selection", language_strings=language_strings) }}">
+            {%- if config.extra.language_switcher_show_lcode -%}
+            <div class="language-switcher-icon language-switcher-icon-with-code"></div>
+            <div class="language-switcher-icon-code">{{lang}}</div>
+            {%- else -%}
             <div class="language-switcher-icon"></div>
+            {%- endif -%}
         </summary>
         <div class="dropdown-content" role="menu">
             {#- Display the current language first in the dropdown -#}

--- a/theme.toml
+++ b/theme.toml
@@ -132,6 +132,9 @@ iine_unified_languages = true
 # Can be set at section levels, following the hierarchy: section > config. See: https://welpo.github.io/tabi/blog/mastering-tabi-settings/#settings-hierarchy
 post_listing_index_reversed = false  # Defaults to false.
 
+# Show current language code on the language switcher
+language_switcher_show_lcode = false # Defaults to false
+
 # DEPRECATED!
 # Use Zola's built-in `bottom_footnotes = true` in the [markdown] section instead. (Available since v0.19.0)
 # Adds backlinks to footnotes (loads ~500 bytes of JavaScripts).


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Add the option to show the current language code at the bottom of the language switcher

## Changes

- Add new `language_switcher_show_lcode` config option that defaults to `false`.
- Update language switcher partial with conditional logic and sass with new class

### Accessibility

Language switcher size is reduced by 30% to allow the language code to fit nicely.

### Screenshots

Before:
<img width="1237" height="79" alt="Screenshot_20250824_230220" src="https://github.com/user-attachments/assets/f52b8d8e-00d3-4bd4-9f7c-105ed17e3226" />

After:
<img width="1254" height="78" alt="Screenshot_20250824_230140" src="https://github.com/user-attachments/assets/0af2377d-1221-4842-bcc1-a16b124fd8b2" />

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [x] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [x] I have updated `theme.toml` with a sane default for the feature
- [x] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [x] Updated `config.toml` comments
  - [x] Updated `theme.toml` comments
  - [x] Updated "Mastering tabi" post in English (more precisely the i18n related `content/blog/faq-languages/index.md` file)
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
