### PR TITLE
✨ feat: added auto-generated summary to post listing and atom feeds

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -169,6 +169,13 @@ show_date = true
 # "both" - Show both the original date and the last updated date.
 post_listing_date = "date"
 
+# Auto generate summary for post listing and Atom feeds.
+# It will be generated in separated paragraph alongside with post description.
+# Auto generated when no summary is set using the <!-- more --> tag.
+auto_generated_summary_length = 300
+auto_generated_post_listing_summary = true
+auto_generated_atom_feed_summary = true
+
 # Enable iine like buttons on all posts: https://iine.to/
 # Can be set at page or section levels, following the hierarchy: page > section > config. See: https://welpo.github.io/tabi/blog/mastering-tabi-settings/#settings-hierarchy
 iine = true

--- a/static/feed_style.xsl
+++ b/static/feed_style.xsl
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  xmlns:atom="http://www.w3.org/2005/Atom" xmlns:tabi="https://github.com/welpo/tabi">
+  xmlns:atom="http://www.w3.org/2005/Atom" xmlns:tabi="https://github.com/welpo/tabi"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
   <xsl:template match="/">
     <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
@@ -100,7 +101,7 @@
                       </a>
                     </div>
                     <div class="description">
-                      <xsl:value-of select="atom:summary"/>
+                      <xsl:copy-of select="atom:summary/xhtml:div/*"/>
                     </div>
                     <a class="readmore" href="">
                       <xsl:attribute name="href">

--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -100,11 +100,18 @@
         {% if config.extra.full_content_in_feed %}
             <content type="html">{{ page.content }}</content>
         {% endif -%}
-        {% if page.description -%}
-            <summary type="html">{{ page.description }}</summary>
-        {% elif page.summary -%}
-            <summary type="html">{{ page.summary | striptags | trim_end_matches(pat=".") | safe }}…</summary>
-        {% endif -%}
+        <summary type="xhtml">
+            <div xmlns="http://www.w3.org/1999/xhtml">
+            {% if page.description -%}
+                <p>{{ page.description | markdown(inline=true) | safe }}</p>
+            {% endif %}
+            {% if page.summary -%}
+                <p>{{ page.summary | striptags | trim_end_matches(pat=".") | safe }}...</p>
+            {% elif config.extra.auto_generated_atom_feed_summary %}
+                <p>{{ page.content | striptags | truncate(length=config.extra.auto_generated_summary_length) | safe }}</p>
+            {% endif %}
+            </div>
+        </summary>
     </entry>
     {%- endfor %}
 </feed>

--- a/templates/macros/list_posts.html
+++ b/templates/macros/list_posts.html
@@ -142,9 +142,12 @@
 
                     <div class="description">
                         {% if post.description %}
-                            <p>{{ post.description | markdown(inline=true) | safe  }}</p>
-                        {% elif post.summary %}
-                            <p>{{ post.summary | markdown(inline=true) | trim_end_matches(pat=".") | safe }}…</p>
+                            <p>{{ post.description | markdown(inline=true) | safe }}</p>
+                        {% endif %}
+                        {% if post.summary %}
+                            <p>{{ post.summary | striptags | trim_end_matches(pat=".") | safe }}...</p>
+                        {% elif config.extra.auto_generated_post_listing_summary %}
+                            <p>{{ post.content | striptags | truncate(length=config.extra.auto_generated_summary_length) | safe }}</p>
                         {% endif %}
                     </div>
                     <a class="readmore" href="{{ post.permalink }}">{{ macros_translate::translate(key="read_more", default="Read more", language_strings=language_strings) }}&nbsp;<span class="arrow">→</span></a>


### PR DESCRIPTION
## Summary

Post listing and Atom feeds will show post summary in separate paragraph alongside with post description.

### Related issue

Closes #491 

## Changes

New config defaults (breaking changes):
- auto_generated_summary_length = 300
- auto_generated_post_listing_summary = true
- auto_generated_atom_feed_summary = true

### Accessibility

No action taken.

### Screenshots

Example of post listing:
<img width="1631" height="1262" alt="image" src="https://github.com/user-attachments/assets/52b678bf-3f03-4cbd-ac89-3f74d3cf24d9" />

Noted the generic striptags cause things like Table of Contents and Headings shown in the summary in a somewhat non-ideal way. But I don't see any clean solution for that.

Example of Atom feeds:

<img width="1937" height="615" alt="image" src="https://github.com/user-attachments/assets/7b5e76e5-c298-4e75-8677-2dd17fc4f492" />

### Type of change

- [ ] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [x] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [ ] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [x] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
