### PR TITLE
✨ feat: allow custom feed icon

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -292,7 +292,9 @@ menu = [
     { name = "projects", url = "projects", trailing_slash = true },
 ]
 
-# The RSS icon will be shown if (1) it's enabled and (2) the following variable is set to true.
+# The RSS icon will be shown if (1) it's enabled and (2) the following variable is set.
+# Set to true to use the default "rss" icon, or specify a custom icon name (e.g. "square-rss").
+# The icon must exist in static/social_icons/ (without the .svg extension).
 # Note for Zola 0.19.X users: when `feed_filenames` has two filenames, only the first one will be linked in the footer.
 feed_icon = true
 

--- a/content/blog/mastering-tabi-settings/index.ca.md
+++ b/content/blog/mastering-tabi-settings/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuració de tabi: guia completa"
 date = 2023-09-18
-updated = 2025-12-27
+updated = 2026-01-01
 description = "Descobreix les múltiples maneres en què pots personalitzar tabi."
 
 [taxonomies]
@@ -883,6 +883,8 @@ Per utilitzar una icona personalitzada, pots afegir-la al directori `static/soci
 |   ❌   |   ❌    |      ✅       |          ❌           |         ❌          |
 
 Pots afegir un enllaç al teu feed RSS/Atom al peu de pàgina amb `feed_icon = true`.
+
+Per utilitzar una icona personalitzada, estableix `feed_icon` amb el nom de la icona (per exemple, `feed_icon = "square-rss"`). La icona ha d'existir a `static/social_icons/` (sense l'extensió `.svg`).
 
 Nota pels usuaris de Zola 0.19.X: quan hi ha dos noms de fitxer a `feed_filenames`, només s'enllaçarà el primer al peu de pàgina.
 

--- a/content/blog/mastering-tabi-settings/index.es.md
+++ b/content/blog/mastering-tabi-settings/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Domina la configuración de tabi: guía completa"
 date = 2023-09-18
-updated = 2025-12-27
+updated = 2026-01-01
 description = "Descubre las múltiples maneras en que puedes personalizar tabi."
 
 [taxonomies]
@@ -888,6 +888,8 @@ Para usar un icono personalizado, puedes añadirlo al directorio `static/social_
 |   ❌   |   ❌    |      ✅       |         ❌        |         ❌          |
 
 Puedes añadir un enlace a tu feed RSS/Atom en el pie de página con `feed_icon = true`.
+
+Para usar un icono personalizado, establece `feed_icon` con el nombre del icono (por ejemplo, `feed_icon = "square-rss"`). El icono debe existir en `static/social_icons/` (sin la extensión `.svg`).
 
 Nota para usuarios de Zola 0.19.X: cuando hay dos nombres de archivo en `feed_filenames`, solo se enlazará el primero en el pie de página.
 

--- a/content/blog/mastering-tabi-settings/index.md
+++ b/content/blog/mastering-tabi-settings/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Mastering tabi Settings: A Comprehensive Guide"
 date = 2023-09-18
-updated = 2025-12-27
+updated = 2026-01-01
 description = "Discover the many ways you can customise your tabi site."
 
 [taxonomies]
@@ -896,6 +896,8 @@ To use a custom icon, you can add it to your site's `static/social_icons` direct
 |  ❌  |   ❌    |      ✅       |         ❌        |         ❌          |
 
 You can add a link to your RSS/Atom feed to the footer with `feed_icon = true`.
+
+To use a custom icon, set `feed_icon` to the icon name (e.g. `feed_icon = "square-rss"`). The icon must exist in `static/social_icons/` (without the `.svg` extension).
 
 Note for Zola 0.19.X users: when there are two filenames in `feed_filenames`, only the first one will be linked in the footer.
 

--- a/templates/macros/feed_utils.html
+++ b/templates/macros/feed_utils.html
@@ -15,3 +15,12 @@
     {%- set feed_url = feed_utils::get_feed_url() -%}
     {{- generate_feed and config.extra.feed_icon and feed_url -}}
 {%- endmacro should_show_footer_feed_icon -%}
+
+{#- Get feed icon name: string value or "rss" for true, empty for false -#}
+{%- macro get_feed_icon_name() -%}
+    {%- if config.extra.feed_icon is string -%}
+        {{- config.extra.feed_icon -}}
+    {%- elif config.extra.feed_icon -%}
+        {{- "rss" -}}
+    {%- endif -%}
+{%- endmacro get_feed_icon_name -%}

--- a/templates/macros/page_header.html
+++ b/templates/macros/page_header.html
@@ -9,8 +9,9 @@
     {{ title -}}
     {% if show_feed_icon %}
         {%- set feed_url = feed_utils::get_feed_url() -%}
+        {%- set feed_icon_name = feed_utils::get_feed_icon_name() -%}
         <a class="no-hover-padding social" rel="{{ rel_attributes }}" {{ blank_target }} href="{{ get_url(path=term.path ~ feed_url, lang=lang, trailing_slash=false) | safe }}">
-            <img loading="lazy" alt="feed" title="feed" src="{{ get_url(path='/social_icons/rss.svg') }}">
+            <img loading="lazy" alt="feed" title="feed" src="{{ get_url(path='/social_icons/' ~ feed_icon_name ~ '.svg') }}">
         </a>
     {% endif %}
 </h1>

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -6,6 +6,7 @@
 
 {#- Feed icon -#}
 {%- set feed_url = feed_utils::get_feed_url() -%}
+{%- set feed_icon_name = feed_utils::get_feed_icon_name() -%}
 {%- set should_show_feed = feed_utils::should_show_footer_feed_icon() == "true" -%}
 
 {%- set should_show_footer_icons = should_show_feed or config.extra.socials or config.extra.email -%}
@@ -18,7 +19,7 @@
                     {%- if should_show_feed -%}
                     <li>
                         <a class="nav-links no-hover-padding social" rel="{{ rel_attributes }}" {{ blank_target }} href="{{ get_url(path=feed_url, lang=lang, trailing_slash=false) | safe }}">
-                        <img loading="lazy" alt="feed" title="feed" src="{{ get_url(path='/social_icons/rss.svg') }}">
+                        <img loading="lazy" alt="feed" title="feed" src="{{ get_url(path='/social_icons/' ~ feed_icon_name ~ '.svg') }}">
                         </a>
                     </li>
                     {%- endif -%}

--- a/theme.toml
+++ b/theme.toml
@@ -240,7 +240,9 @@ menu = [
     { name = "projects", url = "projects", trailing_slash = true },
 ]
 
-# The RSS icon will be shown if (1) it's enabled and (2) the following variable is set to true.
+# The RSS icon will be shown if (1) it's enabled and (2) the following variable is set.
+# Set to true to use the default "rss" icon, or specify a custom icon name (e.g. "square-rss").
+# The icon must exist in static/social_icons/ (without the .svg extension).
 # Note for Zola 0.19.X users: when `feed_filenames` has two filenames, only the first one will be linked in the footer.
 feed_icon = true
 


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary

Allow `feed_icon` to accept a string value specifying a custom icon name, in addition to the existing boolean behavior. This enables users to use alternative feed icons like `square-rss` while maintaining full backwards compatibility.

### Related discussions

#597 and #602

## Changes

Added a new `get_feed_icon_name()` macro to `feed_utils.html` that:
- Returns the string value if `feed_icon` is a string (e.g., `"square-rss"`)
- Returns `"rss"` if `feed_icon` is `true` (backwards compatible)
- Returns empty if `feed_icon` is falsy

Updated `footer.html` and `page_header.html` to use this macro for dynamic icon selection instead of the hardcoded `rss.svg`.

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [ ] Bug fix (fixes an issue without altering functionality)
- [x] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [x] I have updated `theme.toml` with a sane default for the feature
- [X] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [x] I have made corresponding changes to the documentation:
  - [X] Updated `config.toml` comments
  - [x] Updated `theme.toml` comments
  - [x] Updated "Mastering tabi" post in English
  - [x] (Optional) Updated "Mastering tabi" post in Spanish
  - [x] (Optional) Updated "Mastering tabi" post in Catalan
