### PR TITLE
🌐 feat(i18n): add Brazilian Portuguese

### DIFF
--- a/content/blog/faq-languages/index.ca.md
+++ b/content/blog/faq-languages/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Lost in Translation? Explora les capacitats multilingües de tabi"
 date = 2023-09-12
-updated = 2025-09-14
+updated = 2026-01-03
 description = "Descobreix com tabi t'ajuda a connectar amb una audiència global gràcies a les seves funcions multilingües. Aprèn a canviar la llengua per defecte, afegir més llengües i aportar les teves pròpies traduccions."
 
 [taxonomies]
@@ -38,6 +38,7 @@ tabi admet les següents llengües:
 - Odia
 - Persa
 - Portuguès (Europeu)
+- Portuguès (Brasil)
 - Rus
 - Ucraïnès
 - Xinès (Simplificat)

--- a/content/blog/faq-languages/index.es.md
+++ b/content/blog/faq-languages/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "¿Lost in Translation? Explora las capacidades multilingües de tabi"
 date = 2023-09-12
-updated = 2025-09-14
+updated = 2026-01-03
 description = "Descubre cómo tabi te ayuda a conectar con una audiencia global gracias a sus funciones multilingües. Aprende a cambiar el idioma por defecto, añadir más idiomas y aportar tus propias traducciones."
 
 [taxonomies]
@@ -39,6 +39,7 @@ tabi admite los siguientes idiomas:
 - Odia
 - Persa
 - Portugués (Europeo)
+- Portugués (Brasil)
 - Ruso
 - Ucraniano
 

--- a/content/blog/faq-languages/index.md
+++ b/content/blog/faq-languages/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Lost in Translation? Not with tabi's Multilingual Capabilities"
 date = 2023-09-12
-updated = 2025-09-14
+updated = 2026-01-03
 description = "Master the art of serving a global audience through tabi's built-in multilingual features. Learn how to change the default language, add multilingual support, and contribute your own translations."
 
 [taxonomies]
@@ -39,6 +39,7 @@ tabi supports the following languages:
 - Odia
 - Persian
 - Portuguese (European)
+- Portuguese (Brazilian)
 - Russian
 - Spanish
 - Ukranian

--- a/i18n/pt-BR.toml
+++ b/i18n/pt-BR.toml
@@ -1,0 +1,99 @@
+language_name = "Português"  # Shown in language picker for multi-language sites.
+date_locale = "pt_BR"
+full_stop = "."  # Used at the end of a sentence.
+
+# Menu items.
+# Should match the names in config.extra.menu and config.extra.footer_menu.
+blog = "blog"
+archive = "arquivo"
+tags = "marcadores"
+projects = "projetos"
+about = "sobre"
+contact = "contato"
+privacy = "política de privacidade"
+site_statistics = "estatísticas do site"
+sitemap = "mapa do site"
+
+# Search.
+search = "Pesquisar"
+search_icon_title = "Clique ou pressione $SHORTCUT para abrir a pesquisa"  # $SHORTCUT will be replaced with the actual keyboard shortcut.
+clear_search = "Limpar pesquisa"  # Title of the X icon next to search input.
+zero_results = "Nenhum resultado encontrado"
+one_results = "$NUMBER resultado"  # "1 result"
+many_results = "$NUMBER resultados"  # "3 results"
+
+# Navigation.
+skip_to_content = "Pular para o conteúdo"
+pinned = "Fixado"
+jump_to_posts = "Ir para as publicações"
+read_more = "Ler mais"
+one_posts = "$NUMBER publicação"
+many_posts = "$NUMBER publicações"
+prev = "Anterior"  # As in "Previous" page.
+next = "Próximo"  # As in "Next" page.
+of = "de"  # E.g. Page 1 "of" 3
+all_posts = "Todas as publicações"
+all_tags = "Todas os marcadores"
+all_projects = "Todos os projetos"
+featured_projects = "Projetos em destaque"
+language_selection = "Seleção de idioma"
+toggle_mode = "Alternar para o modo $MODE"  # $MODE will be replaced by a value (or both) below.
+dark = "escuro"
+light = "claro"
+reset_mode = "Resetar modo para o padrão"
+
+# Quick navigation buttons.
+toggle_toc = "Alternar Sumário"
+go_to_top = "Ir para o topo da página"
+go_to_comments = "Ir para a seção de comentários"
+
+# Post metadata.
+by_author = "Por $AUTHOR"  # $AUTHOR will be replaced by the author(s).
+author_separator = ", "  # For multiple authors. Ensure spacing where necessary.
+author_conjunction = " e "  # For multiple authors. Ensure spacing where necessary.
+draft = "RASCUNHO"
+zero_min_read = "<1 min de leitura"
+one_min_read = "$NUMBER min de leitura"
+many_min_read = "$NUMBER min de leitura"
+zero_words = "Nenhuma palavra"
+one_words = "$NUMBER palavra"
+many_words = "$NUMBER palavras"
+last_updated_on = "Atualizado em $DATE"
+see_changes = "Ver alterações"
+
+# Post body.
+table_of_contents = "Sumário"
+load_comments = "Carregar comentários"
+
+# Copy code block button.
+copied = "Copiado!"
+copy_code_to_clipboard = "Copiar código para a área de transferência"
+
+# iine appreciation button.
+like_this_post = "Curtir esta publicação"
+
+# Footer: Powered by Zola and tabi.
+powered_by = "Desenvolvido com"
+and = "&"
+site_source = "Código-fonte do site"
+
+# 404 error.
+# https://welpo.github.io/tabi/404.html
+page_missing = "A página que solicitou parece não existir"
+translation_missing = "ou ainda não foi traduzida para o seu idioma"
+check_url = "Verifique se o endereço está correto ou"
+go_home = "volte para a página inicial"
+
+# For multilingual quote shortcode.
+# https://welpo.github.io/tabi/blog/shortcodes/#multilingual-quotes
+show_original_quote = "Mostrar citação original"
+show_translation = "Mostrar tradução"
+open_quotation_mark = "“"
+close_quotation_mark = "”"
+
+# Translations for stylised Atom feed.
+# https://welpo.github.io/tabi/atom.xml
+# Must contain "About Feeds"; it will become a link.
+about_feeds = "Isto é um feed web, também conhecido como feed Atom. Inscreva-se copiando o URL da barra de endereços para o seu leitor de notícias. Visite About Feeds para aprender mais e começar. É grátis."
+visit_the_site = "Visitar site"
+recent_posts = "Publicações recentes"


### PR DESCRIPTION
## Summary

Added Brazilian Portuguese language support. There are some small but important differences from the pt_PR strings.

### Type of change

- [ ] Bug fix (fixes an issue without altering functionality)
- [x] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [ ] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [x] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
