### PR TITLE
✨ feat: add support for github-style alerts

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -37,6 +37,8 @@ bottom_footnotes = true
 smart_punctuation = true
 # Set to 'external' to add an indicator next to external links.
 external_links_class = "external"
+# Enable Github-styled blockquote alerts
+github_alerts = true
 
 [markdown.highlighting]
 theme = "catppuccin-frappe"

--- a/config.toml
+++ b/config.toml
@@ -37,7 +37,7 @@ bottom_footnotes = true
 smart_punctuation = true
 # Set to 'external' to add an indicator next to external links.
 external_links_class = "external"
-# Enable Github-styled blockquote alerts
+# Render GitHub-style alerts, e.g. `> [!NOTE]`. Requires Zola 0.21+.
 github_alerts = true
 
 [markdown.highlighting]

--- a/content/blog/markdown/index.ca.md
+++ b/content/blog/markdown/index.ca.md
@@ -1,7 +1,7 @@
 +++
 title = "Exemples de Markdown"
 date = 2023-01-31
-updated = 2026-01-01
+updated = 2026-06-10
 description = "Aquesta publicació mostra alguns exemples de format en Markdown, incloent-hi una taula, blocs de codi i etiquetes, citacions, taules i notes a peu de pàgina."
 
 [taxonomies]
@@ -112,6 +112,43 @@ A Rust, declares una variable mutable amb `let mut x = 5;`, mentre que a Python,
 > «La vida, perquè sigui vida, s'ha de viure a poc a poc…»
 >
 > — Mercè Rodoreda, La plaça del Diamant
+
+## Alertes estil GitHub
+
+Configurar `github_alerts = true` a la secció `[markdown]` del teu `config.toml` (requereix Zola 0.21+) activa les [alertes estil GitHub](https://docs.github.com/es/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts):
+
+```markdown
+> [!NOTE]
+> Això és una nota!
+>
+> Pot ocupar diversos paràgrafs.
+
+> [!CAUTION]
+> Ves amb compte abans de continuar!
+```
+
+El resultat és:
+
+> [!NOTE]
+> Això és una nota!
+>
+> Pot ocupar diversos paràgrafs.
+
+> [!CAUTION]
+> Ves amb compte abans de continuar!
+
+Els tipus d'alerta disponibles són `NOTE`, `TIP`, `IMPORTANT`, `WARNING` i `CAUTION`.
+
+Les etiquetes es tradueixen automàticament segons l'idioma de la pàgina. Per canviar-les (o afegir un idioma que falti), sobreescriu les variables CSS `--alert-{tipus}-label` amb [CSS personalitzat](@/blog/mastering-tabi-settings/index.ca.md#estils-css-personalitzats):
+
+```css
+html:lang(eo) {
+    --alert-note-label: "Noto";
+    --alert-caution-label: "Atentu";
+}
+```
+
+Per tenir control total sobre el títol, la icona i els colors, consulta el [shortcode d'advertències](@/blog/shortcodes/index.ca.md#advertencies).
 
 ---
 

--- a/content/blog/markdown/index.es.md
+++ b/content/blog/markdown/index.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Ejemplos de Markdown"
 date = 2023-01-31
-updated = 2026-01-01
+updated = 2026-06-10
 description = "Esta publicación muestra algunos ejemplos de formato Markdown, incluyendo una tabla, bloques de código y etiquetas, citas, tablas y notas al pie de página."
 
 [taxonomies]
@@ -112,6 +112,43 @@ En Rust, declaras una variable mutable con `let mut x = 5;`, mientras que en Pyt
 > «A mí me sobra el cuerpo, Orfeo, me sobra el cuerpo porque me falta alma.»
 >
 > — Miguel de Unamuno, Niebla
+
+## Alertas estilo GitHub
+
+Configurar `github_alerts = true` en la sección `[markdown]` de tu `config.toml` (requiere Zola 0.21+) activa las [alertas estilo GitHub](https://docs.github.com/es/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts):
+
+```markdown
+> [!NOTE]
+> ¡Esto es una nota!
+>
+> Puede ocupar varios párrafos.
+
+> [!CAUTION]
+> ¡Ten cuidado antes de continuar!
+```
+
+El resultado es:
+
+> [!NOTE]
+> ¡Esto es una nota!
+>
+> Puede ocupar varios párrafos.
+
+> [!CAUTION]
+> ¡Ten cuidado antes de continuar!
+
+Los tipos de alerta disponibles son `NOTE`, `TIP`, `IMPORTANT`, `WARNING` y `CAUTION`.
+
+Las etiquetas se traducen automáticamente según el idioma de la página. Para cambiarlas (o añadir un idioma que falte), sobreescribe las variables CSS `--alert-{tipo}-label` con [CSS personalizado](@/blog/mastering-tabi-settings/index.es.md#estilos-css-personalizados):
+
+```css
+html:lang(eo) {
+    --alert-note-label: "Noto";
+    --alert-caution-label: "Atentu";
+}
+```
+
+Para tener control total sobre el título, el icono y los colores, consulta el [shortcode de advertencias](@/blog/shortcodes/index.es.md#advertencias).
 
 ---
 

--- a/content/blog/markdown/index.md
+++ b/content/blog/markdown/index.md
@@ -1,7 +1,7 @@
 +++
 title = "Markdown examples"
 date = 2023-01-31
-updated = 2026-01-01
+updated = 2026-06-10
 description = "This post showcases some examples of Markdown formatting, including a table, code blocks and tags, quotes, tables, and footnotes."
 
 [taxonomies]
@@ -113,21 +113,42 @@ In Rust, you declare a mutable variable with `let mut x = 5;`, whereas in Python
 >
 > — Charlie Kaufman, Synecdoche, New York
 
-## Github-style Alerts
-You can use Github-style Alerts by writing
+## GitHub-style alerts
+
+Setting `github_alerts = true` in the `[markdown]` section of your `config.toml` (requires Zola 0.21+) enables [GitHub-style alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts):
+
 ```markdown
 > [!NOTE]
 > This is a note!
+>
+> It can span multiple paragraphs.
+
+> [!CAUTION]
+> Pay caution before continuing!
 ```
 
 The result looks like:
+
 > [!NOTE]
 > This is a note!
+>
+> It can span multiple paragraphs.
 
 > [!CAUTION]
 > Pay caution before continuing!
 
-The supported alert types are `note`, `tip`, `important`, `warning`, or `caution`.
+The supported alert types are `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, and `CAUTION`.
+
+The labels are translated automatically based on the page's language. To change them (or to add a missing language), override the `--alert-{type}-label` CSS variables in [custom CSS](@/blog/mastering-tabi-settings/index.md#custom-css):
+
+```css
+html:lang(eo) {
+    --alert-note-label: "Noto";
+    --alert-caution-label: "Atentu";
+}
+```
+
+For full control over the title, icon, and colours, see the [admonitions shortcode](@/blog/shortcodes/index.md#admonitions).
 
 ---
 

--- a/content/blog/markdown/index.md
+++ b/content/blog/markdown/index.md
@@ -113,6 +113,22 @@ In Rust, you declare a mutable variable with `let mut x = 5;`, whereas in Python
 >
 > — Charlie Kaufman, Synecdoche, New York
 
+## Github-style Alerts
+You can use Github-style Alerts by writing
+```markdown
+> [!NOTE]
+> This is a note!
+```
+
+The result looks like:
+> [!NOTE]
+> This is a note!
+
+> [!CAUTION]
+> Pay caution before continuing!
+
+The supported alert types are `note`, `tip`, `important`, `warning`, or `caution`.
+
 ---
 
 [^1]: And here's an example of a footnote!

--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 # Hello, the Arabic language has many pronouns and words, and each word indicates a different meaning,
 # unlike the English language, in which, on the other hand, the word can refer to a person and a group.
 # This translation is for individual use, if you are a company or organization, I have put a comment in

--- a/i18n/ca.toml
+++ b/i18n/ca.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "Català"  # Shown in language picker for multi-language sites.
 date_locale = "ca_ES"
 full_stop ="."  # Used at the end of a sentence.

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 # This has been machine translated.
 # If you would like to help correct errors or improve the translation,
 # please open an issue or submit a pull request.

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "English"  # Shown in language picker for multi-language sites.
 date_locale = "en_GB"
 full_stop = "."  # Used at the end of a sentence.

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "Español"  # Shown in language picker for multi-language sites.
 date_locale = "es_ES"
 full_stop = "."  # Used at the end of a sentence.

--- a/i18n/et.toml
+++ b/i18n/et.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "Eesti"  # Shown in language picker for multi-language sites.
 date_locale = "et_EE"
 full_stop = "."  # Used at the end of a sentence.

--- a/i18n/fa.toml
+++ b/i18n/fa.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "فارسی"  # Shown in language picker for multi-language sites.
 date_locale = "fa_IR"
 full_stop = "."  # Used at the end of a sentence.

--- a/i18n/fi.toml
+++ b/i18n/fi.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "suomi"  # Shown in language picker for multi-language sites.
 date_locale = "fi_FI"
 full_stop = "."  # Used at the end of a sentence.

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "Français"  # Shown in language picker for multi-language sites.
 date_locale = "fr_FR"
 full_stop = "."  # Used at the end of a sentence.

--- a/i18n/hi.toml
+++ b/i18n/hi.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 # This has been machine translated.
 # If you would like to help correct errors or improve the translation, please open an issue or submit a pull request.
 language_name = "हिंदी"  # Shown in language picker for multi-language sites.

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "Italiano"  # Shown in language picker for multi-language sites.
 date_locale = "it_IT"
 full_stop = "."  # Used at the end of a sentence.

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 # This has been machine translated.
 # If you would like to help correct errors or improve the translation,
 # please open an issue or submit a pull request.

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 # This has been machine translated.
 # If you would like to help correct errors or improve the translation,
 # please open an issue or submit a pull request.

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "Dutch"  # Shown in language picker for multi-language sites.
 date_locale = "nl_NL" #nl_BE can also be used for Flemish
 full_stop = "."  # Used at the end of a sentence.

--- a/i18n/or.toml
+++ b/i18n/or.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "ଓଡ଼ିଆ"  # Shown in language picker for multi-language sites.
 date_locale = "or_IN"
 full_stop = "।"  # Used at the end of a sentence.

--- a/i18n/pt-BR.toml
+++ b/i18n/pt-BR.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "Português"  # Shown in language picker for multi-language sites.
 date_locale = "pt_BR"
 full_stop = "."  # Used at the end of a sentence.

--- a/i18n/pt-PT.toml
+++ b/i18n/pt-PT.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "Português"  # Shown in language picker for multi-language sites.
 date_locale = "pt_PT"
 full_stop = "."  # Used at the end of a sentence.

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "Русский"  # Shown in language picker for multi-language sites.
 date_locale = "ru_RU"
 full-stop = "."  # Used at the end of a sentence.

--- a/i18n/uk.toml
+++ b/i18n/uk.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 # This has been machine translated.
 # If you would like to help correct errors or improve the translation,
 # please open an issue or submit a pull request.

--- a/i18n/zh-Hans.toml
+++ b/i18n/zh-Hans.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "简体中文"  # Shown in language picker for multi-language sites.
 date_locale = "zh_CN"
 full_stop = "。"  # Used at the end of a sentence.

--- a/i18n/zh-Hant.toml
+++ b/i18n/zh-Hant.toml
@@ -1,3 +1,6 @@
+# NOTE: The labels for GitHub-style alerts are defined in sass/parts/_admonitions.scss.
+# Please keep both in sync when adding or updating a language.
+
 language_name = "繁體中文"  # Shown in language picker for multi-language sites.
 date_locale = "zh_TW"
 full_stop = "。"  # Used at the end of a sentence.

--- a/sass/parts/_admonitions.scss
+++ b/sass/parts/_admonitions.scss
@@ -1,3 +1,6 @@
+/* The alert icon is pinned to the box's padding edge, so both must use this value. */
+$admonition-padding: 0.8rem;
+
 /* GitHub-style alerts (Zola's `github_alerts`) reuse the admonition palette and icons. */
 /* Zola only outputs `<blockquote class="markdown-alert-{name}">`, so the title comes from */
 /* the `--alert-{name}-label` custom property (translated per language at the bottom) and the icon from ::after. */
@@ -116,26 +119,26 @@
     }
 }
 
-.admonition {
-    display: flex;
-    align-items: flex-start;
+.admonition,
+[class^='markdown-alert-'] {
     margin-block: 1em;
     border-radius: 10px;
     border-inline-start: 6px solid;
-    padding: 0.8rem;
+    padding: $admonition-padding;
     color: var(--text-color-high-contrast);
     font-family: var(--sans-serif-font);
+    a code {
+        color: inherit;
+    }
+}
 
+.admonition {
+    display: flex;
+    align-items: flex-start;
     p {
         margin-inline-start: -1.75rem;
         margin-block-end: 0;
         font-family: inherit;
-    }
-
-    a {
-        code {
-            color: inherit;
-        }
     }
 }
 
@@ -146,17 +149,22 @@
     }
 }
 
-.admonition-icon {
-    display: flex;
-    align-items: center;
-    margin: 0.3rem;
+.admonition-icon,
+[class^='markdown-alert-']::after {
     background-size: contain;
     background-repeat: no-repeat;
     aspect-ratio: 1/1;
     width: 1.5rem;
 }
 
-.admonition-title {
+.admonition-icon {
+    display: flex;
+    align-items: center;
+    margin: 0.3rem;
+}
+
+.admonition-title,
+[class^='markdown-alert-']::before {
     opacity: 0.92;
     font-weight: bold;
     font-size: 0.82rem;
@@ -196,31 +204,18 @@
 
 [class^='markdown-alert-'] {
     position: relative;
-    margin-block: 1em;
-    border-radius: 10px;
-    border-inline-start: 6px solid;
-    padding: 0.8rem;
-    color: var(--text-color-high-contrast);
-    font-family: var(--sans-serif-font);
 
     &::before {
         display: block;
-        opacity: 0.92;
         margin-inline-start: 2.1rem;
-        font-weight: bold;
-        font-size: 0.82rem;
         line-height: 1.5rem;
         text-transform: uppercase;
     }
 
     &::after {
         position: absolute;
-        inset-block-start: 0.8rem;
-        inset-inline-start: 0.8rem;
-        background-size: contain;
-        background-repeat: no-repeat;
-        aspect-ratio: 1/1;
-        width: 1.5rem;
+        inset-block-start: $admonition-padding;
+        inset-inline-start: $admonition-padding;
         content: '';
     }
 
@@ -230,12 +225,6 @@
 
         + p {
             margin-block-start: 0.6em;
-        }
-    }
-
-    a {
-        code {
-            color: inherit;
         }
     }
 }

--- a/sass/parts/_admonitions.scss
+++ b/sass/parts/_admonitions.scss
@@ -1,10 +1,16 @@
-@mixin admonition-type($type) {
+/* Base style that's shared among admonitions and GitHub-style alerts */
+@mixin admonition-type-base($type) {
     border-color: var(--admonition-#{$type}-border);
     background-color: var(--admonition-#{$type}-bg);
 
-    > .admonition-content > p > code {
-        background-color: var(--admonition-#{$type}-code);
-    }
+    display: flex;
+    align-items: flex-start;
+    margin-block: 1em;
+    border-radius: 10px;
+    border-inline-start: 6px solid;
+    padding: 0.8rem;
+    color: var(--text-color-high-contrast);
+    font-family: var(--sans-serif-font);
 
     a {
         border-bottom: 1px solid var(--admonition-#{$type}-border);
@@ -14,10 +20,94 @@
             background-color: var(--admonition-#{$type}-border);
             color: var(--hover-color);
         }
+
+        code {
+            color: inherit;
+        }
     }
 
-    .admonition-icon {
-        background-color: var(--admonition-#{$type}-border);
+    p {
+        strong {
+            font-weight: 580;
+        }
+    }
+}
+
+@mixin admonition-type-icon($type) {
+    display: flex;
+    align-items: center;
+    margin: 0.3rem;
+    background-size: contain;
+    background-repeat: no-repeat;
+    aspect-ratio: 1/1;
+    width: 1.5rem;
+    background-color: var(--admonition-#{$type}-border);
+
+    @if $type == note {
+      @include admonition-icon-note-mask;
+    } @else if $type == tip {
+      @include admonition-icon-tip-mask;
+    } @else if $type == info {
+      @include admonition-icon-info-mask;
+    } @else if $type == warning {
+      @include admonition-icon-warning-mask;
+    } @else if $type == danger {
+      @include admonition-icon-danger-mask;
+    }
+    // would be nicer if SASS would support in mixins
+    // i.e. @include admonition-icon-#{$type}-mask;
+}
+
+/* Admonition specific styles */
+@mixin admonition-type($type) {
+    @include admonition-type-base($type);
+    
+    > .admonition-content {
+        flex: 1;
+
+        > p {
+            margin-inline-start: -1.75rem;
+            margin-block-end: 0;
+            font-family: inherit;
+
+            > code {
+                background-color: var(--admonition-#{$type}-code);
+            }
+        }
+    }
+
+    > .admonition-icon {
+        @include admonition-type-icon($type);
+    }
+}
+
+/* Github-alert specific styles */
+@mixin alert-type($type) {
+    @include admonition-type-base($type);
+    
+    > p {
+        &::before {
+            content: "#{$type}\A";
+            text-transform: uppercase;
+            white-space: pre;
+            margin-inline-start: 1.5rem;
+            font-weight: 620;
+            font-size: 1rem;
+        }
+
+        margin-block: 0;
+        margin-inline-start: -1.5rem;
+        font-family: inherit;
+
+        > code {
+            background-color: var(--admonition-#{$type}-code);
+        }
+    }
+
+
+    &::before {
+        content: "";
+        @include admonition-type-icon($type);
     }
 }
 
@@ -85,70 +175,23 @@
     }
 }
 
-.admonition {
-    display: flex;
-    align-items: flex-start;
-    margin-block: 1em;
-    border-radius: 10px;
-    border-inline-start: 6px solid;
-    padding: 0.8rem;
-    color: var(--text-color-high-contrast);
-    font-family: var(--sans-serif-font);
-
-    p {
-        margin-inline-start: -1.75rem;
-        margin-block-end: 0;
-        font-family: inherit;
-    }
-
-    a {
-        code {
-            color: inherit;
-        }
-    }
-}
-
-.admonition-content {
-    flex: 1;
-    strong {
-        font-weight: 580;
-    }
-}
-
-.admonition-icon {
-    display: flex;
-    align-items: center;
-    margin: 0.3rem;
-    background-size: contain;
-    background-repeat: no-repeat;
-    aspect-ratio: 1/1;
-    width: 1.5rem;
-}
-
-.admonition-title {
-    opacity: 0.92;
-    font-weight: bold;
-    font-size: 0.82rem;
-}
-
-
-.admonition-icon-note {
+@mixin admonition-icon-note-mask {
     -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -960 960 960' %3E%3Cpath d='M440-280h80v-240h-80v240Zm40-320q17 0 28.5-11.5T520-640q0-17-11.5-28.5T480-680q-17 0-28.5 11.5T440-640q0 17 11.5 28.5T480-600Zm0 520q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z'/%3E%3C/svg%3E");
 }
 
-.admonition-icon-tip {
+@mixin admonition-icon-tip-mask {
     -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -960 960 960' %3E%3Cpath d='M480-78.258q-33.718 0-56.974-22.166-23.256-22.167-23.59-55.885h161.128q-.334 33.718-23.59 55.885Q513.718-78.258 480-78.258ZM318.257-210.515v-67.588h323.486v67.588H318.257Zm7.846-121.128q-67.692-42.487-106.896-109.134-39.205-66.648-39.205-147.479 0-123.769 88.149-211.884 88.149-88.115 211.967-88.115 123.817 0 211.849 88.115 88.031 88.115 88.031 211.884 0 80.831-38.999 147.479-39 66.647-107.102 109.134H326.103Zm21.927-67.588h264.351q46.311-32 73.17-81.681 26.859-49.68 26.859-107.144 0-96.918-68-164.765-68-67.846-164.564-67.846t-164.41 67.713q-67.846 67.712-67.846 164.725 0 57.52 26.859 107.259t73.581 81.739Zm131.97 0Z'/%3E%3C/svg%3E");
 }
 
-.admonition-icon-info {
+@mixin admonition-icon-info-mask {
     -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -960 960 960' %3E%3Cpath d='M479.789-288Q495-288 505.5-298.289q10.5-10.29 10.5-25.5Q516-339 505.711-349.5q-10.29-10.5-25.5-10.5Q465-360 454.5-349.711q-10.5 10.29-10.5 25.5Q444-309 454.289-298.5q10.29 10.5 25.5 10.5ZM444-432h72v-240h-72v240Zm36.276 336Q401-96 331-126q-70-30-122.5-82.5T126-330.958q-30-69.959-30-149.5Q96-560 126-629.5t82.5-122Q261-804 330.958-834q69.959-30 149.5-30Q560-864 629.5-834t122 82.5Q804-699 834-629.276q30 69.725 30 149Q864-401 834-331q-30 70-82.5 122.5T629.276-126q-69.725 30-149 30ZM480-168q130 0 221-91t91-221q0-130-91-221t-221-91q-130 0-221 91t-91 221q0 130 91 221t221 91Zm0-312Z'/%3E%3C/svg%3E");
 }
 
-.admonition-icon-warning {
+@mixin admonition-icon-warning-mask {
     -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -960 960 960' %3E%3Cpath d='M109-120q-11 0-20-5.5T75-140q-5-9-5.5-19.5T75-180l370-640q6-10 15.5-15t19.5-5q10 0 19.5 5t15.5 15l370 640q6 10 5.5 20.5T885-140q-5 9-14 14.5t-20 5.5H109Zm69-80h604L480-720 178-200Zm302-40q17 0 28.5-11.5T520-280q0-17-11.5-28.5T480-320q-17 0-28.5 11.5T440-280q0 17 11.5 28.5T480-240Zm0-120q17 0 28.5-11.5T520-400v-120q0-17-11.5-28.5T480-560q-17 0-28.5 11.5T440-520v120q0 17 11.5 28.5T480-360Zm0-100Z'/%3E%3C/svg%3E");
 }
 
-.admonition-icon-danger {
+@mixin admonition-icon-danger-mask {
     -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -960 960 960' %3E%3Cpath d='M239.256-400q0 58.091 27.975 108.995t76.13 81.237q-5.616-8.513-8.487-18.398-2.872-9.885-2.872-19.167 1.333-26.436 12.153-50.307 10.821-23.872 31.41-43.461L480-443.921l105.819 102.82q18.923 19.311 29.885 43.321 10.961 24.011 12.294 50.447 0 9.282-2.872 19.167-2.871 9.885-7.82 18.398 47.488-30.333 75.796-81.237Q721.41-341.909 721.41-400q0-47.622-19.258-93.169-19.259-45.547-53.998-82.549-19.951 13.41-42.202 19.859Q583.7-549.41 561-549.41q-62.448 0-105.108-38.039-42.661-38.038-51.225-98.628v-9.744q-39.385 31.949-69.898 67.68-30.513 35.73-51.987 74.166t-32.5 77.464Q239.256-437.483 239.256-400ZM480-349.539l-57.436 56.436q-12.154 11.821-17.731 26.029-5.577 14.208-5.577 29.074 0 32.769 23.498 55.757 23.497 22.987 57.246 22.987 33.432 0 57.421-22.906 23.989-22.906 23.989-55.561 0-16.162-6.116-30.162-6.116-13.999-17.454-25.154l-57.84-56.5Zm-11.002-469.022V-708q0 38.637 26.832 64.819 26.831 26.183 65.17 26.183 15.609 0 30.818-5.923 15.208-5.923 28.131-17.718l22.615-24.102q67.564 44.128 106.999 114.917 39.435 70.79 39.435 150.156 0 128.206-89.846 218.103Q609.307-91.668 480-91.668q-129.027 0-218.68-89.652-89.652-89.653-89.652-218.68 0-119.178 79.371-232.447t217.959-186.114Z'/%3E%3C/svg%3E");
 }
 
@@ -157,3 +200,9 @@
 .admonition.info { @include admonition-type('info'); }
 .admonition.warning { @include admonition-type('warning'); }
 .admonition.danger { @include admonition-type('danger'); }
+
+.markdown-alert-note { @include alert-type('note'); }
+.markdown-alert-tip { @include alert-type('tip'); }
+.markdown-alert-important { @include alert-type('info'); }
+.markdown-alert-warning { @include alert-type('warning'); }
+.markdown-alert-caution { @include alert-type('danger'); }

--- a/sass/parts/_admonitions.scss
+++ b/sass/parts/_admonitions.scss
@@ -1,16 +1,41 @@
-/* Base style that's shared among admonitions and GitHub-style alerts */
-@mixin admonition-type-base($type) {
+/* GitHub-style alerts (Zola's `github_alerts`) reuse the admonition palette and icons. */
+/* Zola only outputs `<blockquote class="markdown-alert-{name}">`, so the title comes from */
+/* the `--alert-{name}-label` custom property (translated per language at the bottom) and the icon from ::after. */
+/* Inline styles are blocked by the default CSP, so the labels must live in the stylesheet. */
+@mixin alert-type($name, $color, $label) {
+    border-color: var(--admonition-#{$color}-border);
+    background-color: var(--admonition-#{$color}-bg);
+
+    > p > code {
+        background-color: var(--admonition-#{$color}-code);
+    }
+
+    a {
+        border-bottom: 1px solid var(--admonition-#{$color}-border);
+        color: var(--admonition-#{$color}-border);
+
+        &:hover {
+            background-color: var(--admonition-#{$color}-border);
+            color: var(--hover-color);
+        }
+    }
+
+    &::before {
+        content: var(--alert-#{$name}-label, '#{$label}');
+    }
+
+    &::after {
+        background-color: var(--admonition-#{$color}-border);
+    }
+}
+
+@mixin admonition-type($type) {
     border-color: var(--admonition-#{$type}-border);
     background-color: var(--admonition-#{$type}-bg);
 
-    display: flex;
-    align-items: flex-start;
-    margin-block: 1em;
-    border-radius: 10px;
-    border-inline-start: 6px solid;
-    padding: 0.8rem;
-    color: var(--text-color-high-contrast);
-    font-family: var(--sans-serif-font);
+    > .admonition-content > p > code {
+        background-color: var(--admonition-#{$type}-code);
+    }
 
     a {
         border-bottom: 1px solid var(--admonition-#{$type}-border);
@@ -20,94 +45,10 @@
             background-color: var(--admonition-#{$type}-border);
             color: var(--hover-color);
         }
-
-        code {
-            color: inherit;
-        }
     }
 
-    p {
-        strong {
-            font-weight: 580;
-        }
-    }
-}
-
-@mixin admonition-type-icon($type) {
-    display: flex;
-    align-items: center;
-    margin: 0.3rem;
-    background-size: contain;
-    background-repeat: no-repeat;
-    aspect-ratio: 1/1;
-    width: 1.5rem;
-    background-color: var(--admonition-#{$type}-border);
-
-    @if $type == note {
-      @include admonition-icon-note-mask;
-    } @else if $type == tip {
-      @include admonition-icon-tip-mask;
-    } @else if $type == info {
-      @include admonition-icon-info-mask;
-    } @else if $type == warning {
-      @include admonition-icon-warning-mask;
-    } @else if $type == danger {
-      @include admonition-icon-danger-mask;
-    }
-    // would be nicer if SASS would support in mixins
-    // i.e. @include admonition-icon-#{$type}-mask;
-}
-
-/* Admonition specific styles */
-@mixin admonition-type($type) {
-    @include admonition-type-base($type);
-    
-    > .admonition-content {
-        flex: 1;
-
-        > p {
-            margin-inline-start: -1.75rem;
-            margin-block-end: 0;
-            font-family: inherit;
-
-            > code {
-                background-color: var(--admonition-#{$type}-code);
-            }
-        }
-    }
-
-    > .admonition-icon {
-        @include admonition-type-icon($type);
-    }
-}
-
-/* Github-alert specific styles */
-@mixin alert-type($type) {
-    @include admonition-type-base($type);
-    
-    > p {
-        &::before {
-            content: "#{$type}\A";
-            text-transform: uppercase;
-            white-space: pre;
-            margin-inline-start: 1.5rem;
-            font-weight: 620;
-            font-size: 1rem;
-        }
-
-        margin-block: 0;
-        margin-inline-start: -1.5rem;
-        font-family: inherit;
-
-        > code {
-            background-color: var(--admonition-#{$type}-code);
-        }
-    }
-
-
-    &::before {
-        content: "";
-        @include admonition-type-icon($type);
+    .admonition-icon {
+        background-color: var(--admonition-#{$type}-border);
     }
 }
 
@@ -175,23 +116,75 @@
     }
 }
 
-@mixin admonition-icon-note-mask {
+.admonition {
+    display: flex;
+    align-items: flex-start;
+    margin-block: 1em;
+    border-radius: 10px;
+    border-inline-start: 6px solid;
+    padding: 0.8rem;
+    color: var(--text-color-high-contrast);
+    font-family: var(--sans-serif-font);
+
+    p {
+        margin-inline-start: -1.75rem;
+        margin-block-end: 0;
+        font-family: inherit;
+    }
+
+    a {
+        code {
+            color: inherit;
+        }
+    }
+}
+
+.admonition-content {
+    flex: 1;
+    strong {
+        font-weight: 580;
+    }
+}
+
+.admonition-icon {
+    display: flex;
+    align-items: center;
+    margin: 0.3rem;
+    background-size: contain;
+    background-repeat: no-repeat;
+    aspect-ratio: 1/1;
+    width: 1.5rem;
+}
+
+.admonition-title {
+    opacity: 0.92;
+    font-weight: bold;
+    font-size: 0.82rem;
+}
+
+
+.admonition-icon-note,
+.markdown-alert-note::after {
     -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -960 960 960' %3E%3Cpath d='M440-280h80v-240h-80v240Zm40-320q17 0 28.5-11.5T520-640q0-17-11.5-28.5T480-680q-17 0-28.5 11.5T440-640q0 17 11.5 28.5T480-600Zm0 520q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z'/%3E%3C/svg%3E");
 }
 
-@mixin admonition-icon-tip-mask {
+.admonition-icon-tip,
+.markdown-alert-tip::after {
     -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -960 960 960' %3E%3Cpath d='M480-78.258q-33.718 0-56.974-22.166-23.256-22.167-23.59-55.885h161.128q-.334 33.718-23.59 55.885Q513.718-78.258 480-78.258ZM318.257-210.515v-67.588h323.486v67.588H318.257Zm7.846-121.128q-67.692-42.487-106.896-109.134-39.205-66.648-39.205-147.479 0-123.769 88.149-211.884 88.149-88.115 211.967-88.115 123.817 0 211.849 88.115 88.031 88.115 88.031 211.884 0 80.831-38.999 147.479-39 66.647-107.102 109.134H326.103Zm21.927-67.588h264.351q46.311-32 73.17-81.681 26.859-49.68 26.859-107.144 0-96.918-68-164.765-68-67.846-164.564-67.846t-164.41 67.713q-67.846 67.712-67.846 164.725 0 57.52 26.859 107.259t73.581 81.739Zm131.97 0Z'/%3E%3C/svg%3E");
 }
 
-@mixin admonition-icon-info-mask {
+.admonition-icon-info,
+.markdown-alert-important::after {
     -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -960 960 960' %3E%3Cpath d='M479.789-288Q495-288 505.5-298.289q10.5-10.29 10.5-25.5Q516-339 505.711-349.5q-10.29-10.5-25.5-10.5Q465-360 454.5-349.711q-10.5 10.29-10.5 25.5Q444-309 454.289-298.5q10.29 10.5 25.5 10.5ZM444-432h72v-240h-72v240Zm36.276 336Q401-96 331-126q-70-30-122.5-82.5T126-330.958q-30-69.959-30-149.5Q96-560 126-629.5t82.5-122Q261-804 330.958-834q69.959-30 149.5-30Q560-864 629.5-834t122 82.5Q804-699 834-629.276q30 69.725 30 149Q864-401 834-331q-30 70-82.5 122.5T629.276-126q-69.725 30-149 30ZM480-168q130 0 221-91t91-221q0-130-91-221t-221-91q-130 0-221 91t-91 221q0 130 91 221t221 91Zm0-312Z'/%3E%3C/svg%3E");
 }
 
-@mixin admonition-icon-warning-mask {
+.admonition-icon-warning,
+.markdown-alert-warning::after {
     -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -960 960 960' %3E%3Cpath d='M109-120q-11 0-20-5.5T75-140q-5-9-5.5-19.5T75-180l370-640q6-10 15.5-15t19.5-5q10 0 19.5 5t15.5 15l370 640q6 10 5.5 20.5T885-140q-5 9-14 14.5t-20 5.5H109Zm69-80h604L480-720 178-200Zm302-40q17 0 28.5-11.5T520-280q0-17-11.5-28.5T480-320q-17 0-28.5 11.5T440-280q0 17 11.5 28.5T480-240Zm0-120q17 0 28.5-11.5T520-400v-120q0-17-11.5-28.5T480-560q-17 0-28.5 11.5T440-520v120q0 17 11.5 28.5T480-360Zm0-100Z'/%3E%3C/svg%3E");
 }
 
-@mixin admonition-icon-danger-mask {
+.admonition-icon-danger,
+.markdown-alert-caution::after {
     -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -960 960 960' %3E%3Cpath d='M239.256-400q0 58.091 27.975 108.995t76.13 81.237q-5.616-8.513-8.487-18.398-2.872-9.885-2.872-19.167 1.333-26.436 12.153-50.307 10.821-23.872 31.41-43.461L480-443.921l105.819 102.82q18.923 19.311 29.885 43.321 10.961 24.011 12.294 50.447 0 9.282-2.872 19.167-2.871 9.885-7.82 18.398 47.488-30.333 75.796-81.237Q721.41-341.909 721.41-400q0-47.622-19.258-93.169-19.259-45.547-53.998-82.549-19.951 13.41-42.202 19.859Q583.7-549.41 561-549.41q-62.448 0-105.108-38.039-42.661-38.038-51.225-98.628v-9.744q-39.385 31.949-69.898 67.68-30.513 35.73-51.987 74.166t-32.5 77.464Q239.256-437.483 239.256-400ZM480-349.539l-57.436 56.436q-12.154 11.821-17.731 26.029-5.577 14.208-5.577 29.074 0 32.769 23.498 55.757 23.497 22.987 57.246 22.987 33.432 0 57.421-22.906 23.989-22.906 23.989-55.561 0-16.162-6.116-30.162-6.116-13.999-17.454-25.154l-57.84-56.5Zm-11.002-469.022V-708q0 38.637 26.832 64.819 26.831 26.183 65.17 26.183 15.609 0 30.818-5.923 15.208-5.923 28.131-17.718l22.615-24.102q67.564 44.128 106.999 114.917 39.435 70.79 39.435 150.156 0 128.206-89.846 218.103Q609.307-91.668 480-91.668q-129.027 0-218.68-89.652-89.652-89.653-89.652-218.68 0-119.178 79.371-232.447t217.959-186.114Z'/%3E%3C/svg%3E");
 }
 
@@ -201,8 +194,76 @@
 .admonition.warning { @include admonition-type('warning'); }
 .admonition.danger { @include admonition-type('danger'); }
 
-.markdown-alert-note { @include alert-type('note'); }
-.markdown-alert-tip { @include alert-type('tip'); }
-.markdown-alert-important { @include alert-type('info'); }
-.markdown-alert-warning { @include alert-type('warning'); }
-.markdown-alert-caution { @include alert-type('danger'); }
+[class^='markdown-alert-'] {
+    position: relative;
+    margin-block: 1em;
+    border-radius: 10px;
+    border-inline-start: 6px solid;
+    padding: 0.8rem;
+    color: var(--text-color-high-contrast);
+    font-family: var(--sans-serif-font);
+
+    &::before {
+        display: block;
+        opacity: 0.92;
+        margin-inline-start: 2.1rem;
+        font-weight: bold;
+        font-size: 0.82rem;
+        line-height: 1.5rem;
+        text-transform: uppercase;
+    }
+
+    &::after {
+        position: absolute;
+        inset-block-start: 0.8rem;
+        inset-inline-start: 0.8rem;
+        background-size: contain;
+        background-repeat: no-repeat;
+        aspect-ratio: 1/1;
+        width: 1.5rem;
+        content: '';
+    }
+
+    p {
+        margin-block: 0;
+        font-family: inherit;
+
+        + p {
+            margin-block-start: 0.6em;
+        }
+    }
+
+    a {
+        code {
+            color: inherit;
+        }
+    }
+}
+
+.markdown-alert-note { @include alert-type('note', 'note', 'Note'); }
+.markdown-alert-tip { @include alert-type('tip', 'tip', 'Tip'); }
+.markdown-alert-important { @include alert-type('important', 'info', 'Important'); }
+.markdown-alert-warning { @include alert-type('warning', 'warning', 'Warning'); }
+.markdown-alert-caution { @include alert-type('caution', 'danger', 'Caution'); }
+
+/* Translated alert labels, one block per supported language; English is the fallback in alert-type. */
+/* `:where()` keeps specificity at zero so the variables can be overridden from custom CSS. */
+html:where(:lang(ar)) { --alert-note-label: 'ملاحظة'; --alert-tip-label: 'نصيحة'; --alert-important-label: 'مهم'; --alert-warning-label: 'تحذير'; --alert-caution-label: 'انتباه'; }
+html:where(:lang(ca)) { --alert-note-label: 'Nota'; --alert-tip-label: 'Consell'; --alert-important-label: 'Important'; --alert-warning-label: 'Advertència'; --alert-caution-label: 'Precaució'; }
+html:where(:lang(de)) { --alert-note-label: 'Hinweis'; --alert-tip-label: 'Tipp'; --alert-important-label: 'Wichtig'; --alert-warning-label: 'Warnung'; --alert-caution-label: 'Vorsicht'; }
+html:where(:lang(es)) { --alert-note-label: 'Nota'; --alert-tip-label: 'Consejo'; --alert-important-label: 'Importante'; --alert-warning-label: 'Advertencia'; --alert-caution-label: 'Precaución'; }
+html:where(:lang(et)) { --alert-note-label: 'Märkus'; --alert-tip-label: 'Vihje'; --alert-important-label: 'Tähtis'; --alert-warning-label: 'Hoiatus'; --alert-caution-label: 'Ettevaatust'; }
+html:where(:lang(fa)) { --alert-note-label: 'یادداشت'; --alert-tip-label: 'نکته'; --alert-important-label: 'مهم'; --alert-warning-label: 'هشدار'; --alert-caution-label: 'احتیاط'; }
+html:where(:lang(fi)) { --alert-note-label: 'Huomautus'; --alert-tip-label: 'Vinkki'; --alert-important-label: 'Tärkeää'; --alert-warning-label: 'Varoitus'; --alert-caution-label: 'Huomio'; }
+html:where(:lang(fr)) { --alert-note-label: 'Note'; --alert-tip-label: 'Astuce'; --alert-important-label: 'Important'; --alert-warning-label: 'Avertissement'; --alert-caution-label: 'Attention'; }
+html:where(:lang(hi)) { --alert-note-label: 'नोट'; --alert-tip-label: 'सुझाव'; --alert-important-label: 'महत्त्वपूर्ण'; --alert-warning-label: 'चेतावनी'; --alert-caution-label: 'सावधानी'; }
+html:where(:lang(it)) { --alert-note-label: 'Nota'; --alert-tip-label: 'Suggerimento'; --alert-important-label: 'Importante'; --alert-warning-label: 'Avviso'; --alert-caution-label: 'Attenzione'; }
+html:where(:lang(ja)) { --alert-note-label: 'メモ'; --alert-tip-label: 'ヒント'; --alert-important-label: '重要'; --alert-warning-label: '警告'; --alert-caution-label: '注意'; }
+html:where(:lang(ko)) { --alert-note-label: '참고'; --alert-tip-label: '팁'; --alert-important-label: '중요'; --alert-warning-label: '경고'; --alert-caution-label: '주의'; }
+html:where(:lang(nl)) { --alert-note-label: 'Opmerking'; --alert-tip-label: 'Tip'; --alert-important-label: 'Belangrijk'; --alert-warning-label: 'Waarschuwing'; --alert-caution-label: 'Let op'; }
+html:where(:lang(or)) { --alert-note-label: 'ଟିପ୍ପଣୀ'; --alert-tip-label: 'ପରାମର୍ଶ'; --alert-important-label: 'ଗୁରୁତ୍ୱପୂର୍ଣ୍ଣ'; --alert-warning-label: 'ଚେତାବନୀ'; --alert-caution-label: 'ସାବଧାନ'; }
+html:where(:lang(pt)) { --alert-note-label: 'Nota'; --alert-tip-label: 'Dica'; --alert-important-label: 'Importante'; --alert-warning-label: 'Aviso'; --alert-caution-label: 'Cuidado'; }
+html:where(:lang(ru)) { --alert-note-label: 'Примечание'; --alert-tip-label: 'Совет'; --alert-important-label: 'Важно'; --alert-warning-label: 'Предупреждение'; --alert-caution-label: 'Осторожно'; }
+html:where(:lang(uk)) { --alert-note-label: 'Примітка'; --alert-tip-label: 'Порада'; --alert-important-label: 'Важливо'; --alert-warning-label: 'Попередження'; --alert-caution-label: 'Обережно'; }
+html:where(:lang(zh-Hans)) { --alert-note-label: '备注'; --alert-tip-label: '提示'; --alert-important-label: '重要'; --alert-warning-label: '警告'; --alert-caution-label: '注意'; }
+html:where(:lang(zh-Hant)) { --alert-note-label: '備註'; --alert-tip-label: '提示'; --alert-important-label: '重要'; --alert-warning-label: '警告'; --alert-caution-label: '注意'; }


### PR DESCRIPTION
<!--
  Thank you for contributing to tabi!

  This template is designed to guide you through the pull request process.
  Please fill out the sections below as applicable.

  Don't worry if your PR is not complete or you're unsure about something;
  feel free to submit it and ask for feedback. We appreciate all contributions, big or small!

  Feel free to remove any section or checklist item that does not apply to your changes.
  If it's a quick fix (for example, fixing a typo), a Summary is enough.
-->

## Summary
- This PR adds support for Github-like alerts as described in (https://www.getzola.org/documentation/getting-started/configuration/, github_alerts documentation)
- To do this, we re-use the existing admonition styles

### Related issue
- I don't think there's any?

## Changes
- Style the classes assigned to GitHub alerts by Zola (`.markdown-alert-note`, `.markdown-alert-info`, ...) similar to admonitions
- This is a bit hacky because we use `::before` two times to inject the icon and the admonition title - but I don't know if it's possible to change the HTML Zola generates, and if it's possible, it's probably more complicated
- I've also added an example and a short explanation in the `markdown` documentation blog post

### Accessibility
- No accessibility tests. I think these were already done for admonitions, so as I re-use the existing code, I don't think any extra work is needed here?

### Screenshots
<img width="789" height="262" alt="Screenshot from 2026-06-08 22-45-26" src="https://github.com/user-attachments/assets/061fb0e3-87c9-43ca-9d0a-495098ab8c41" />


- on the top is the Github alert with `> [!CAUTION]`
- on the bottom is the admonition with `{{ admonition(type="danger", text=...) }}`

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [X] New feature (adds non-breaking functionality)
- [X] Documentation update

---

## Checklist

- [X] I have verified the accessibility of my changes (opened it in a browser and looked fine :) )
- [X] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [X] I have made corresponding changes to the documentation:
  - [X] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments (not needed I think?)
  - [X] Updated "Mastering tabi" post in English (the markdown post)
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan

PS: I'm not really familiar with SASS, so if there's any cool feature in SASS to simplify the code, I'm happy to change it :)