### PR TITLE
📝 docs: add soumendrak.com to sites using tabi

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ git pull
 | [b1n.io](https://b1n.io) | [b1nhack](https://github.com/b1nhack) | Linux kernel vulnerability researcher | [Source](https://github.com/b1nhack/blog) |
 | [posixlycorrect.com](https://posixlycorrect.com/) | [Fabian Montero](https://git.posixlycorrect.com/fabian) | Personal homepage | [Source](https://git.posixlycorrect.com/fabian/homepage) |
 | [Coded Chords](https://codedchords.dev/) | [yostos](https://github.com/yostos) | Personal tech blog | [Source](https://github.com/yostos/blog-yostos) |
+| [soumendrak.com](https://www.soumendrak.com) | [Soumendra Kumar Sahoo](https://github.com/soumendrak) | Personal blog: AI observability, engineering, and weekly notes | &mdash; |
 
 Using tabi? Feel free to create a PR and add your site to this list.
 


### PR DESCRIPTION
## Summary

Add [soumendrak.com](https://www.soumendrak.com) to the "Sites using tabi" list in the README.

The site footer links to the tabi theme (verified at https://www.soumendrak.com). Site source is private, so the Site Source column uses `&mdash;`, consistent with other private-source entries (e.g. Ponderosa Games).

## Changes

- README.md: one new table row under "Sites using tabi":
  - Website: soumendrak.com
  - Creator: Soumendra Kumar Sahoo
  - Description: Personal blog — AI observability, engineering, and weekly notes
  - Site Source: &mdash; (private)

No other files changed. Accessibility: N/A (README table row).