### PR TITLE
🐛 fix(search): fix listener leak on search results

### DIFF
--- a/static/js/searchElasticlunr.js
+++ b/static/js/searchElasticlunr.js
@@ -2678,6 +2678,30 @@ window.onload = function () {
         clearSearchButton.style.display = 'none';
     }
 
+    results.addEventListener('mouseover', function (event) {
+        if (event.target.closest('div[role="option"]')) {
+            updateSelection(event.target.closest('div[role="option"]'));
+        }
+    });
+
+    results.addEventListener('click', function (event) {
+        const clickedElement = event.target.closest('a');
+        if (clickedElement) {
+            const clickedHref = clickedElement.getAttribute('href');
+            const currentPageUrl = window.location.href;
+
+            // Normalise URLs by removing the text fragment and trailing slash.
+            const normalizeUrl = (url) => url.split('#')[0].replace(/\/$/, '');
+
+            // Check if the clicked link matches the current page.
+            // If using Ctrl+click or Cmd+click, don't close the modal.
+            if (normalizeUrl(clickedHref) === normalizeUrl(currentPageUrl) &&
+                !event.ctrlKey && !event.metaKey) {
+                closeModal();
+            }
+        }
+    });
+
     // Close modal when clicking/tapping outside.
     function handleModalInteraction(event) {
         if (event.target === searchModal) {
@@ -3012,30 +3036,6 @@ window.onload = function () {
             if (results.firstChild) {
                 updateSelection(results.firstChild);
             }
-
-            results.addEventListener('mouseover', function (event) {
-                if (event.target.closest('div[role="option"]')) {
-                    updateSelection(event.target.closest('div[role="option"]'));
-                }
-            });
-
-            results.addEventListener('click', function(event) {
-                const clickedElement = event.target.closest('a');
-                if (clickedElement) {
-                    const clickedHref = clickedElement.getAttribute('href');
-                    const currentPageUrl = window.location.href;
-
-                    // Normalise URLs by removing the text fragment and trailing slash.
-                    const normalizeUrl = (url) => url.split('#')[0].replace(/\/$/, '');
-
-                    // Check if the clicked link matches the current page.
-                    // If using Ctrl+click or Cmd+click, don't close the modal.
-                    if (normalizeUrl(clickedHref) === normalizeUrl(currentPageUrl) &&
-                        !event.ctrlKey && !event.metaKey) {
-                        closeModal();
-                    }
-                }
-            });
 
             // Add touch events to the results.
             setupTouchEvents();


### PR DESCRIPTION
## Summary

Move the results container's `mouseover` and `click` listeners out of the per-keystroke `input` handler and into the one-time search setup, so they're bound once instead of accumulating.

### Related issue

Resolves #666

## Changes

The `mouseover` and `click` listeners on `#results` were registered inside the `input` event handler, so every keystroke bound a fresh pair of listeners to the same, persistent `#results` element. `results.innerHTML = ''` clears the element's children but not listeners on the element itself, so nothing ever removed the old ones and the count grew unbounded the longer someone typed. The handlers are idempotent, so this wasn't visibly broken, but it was a genuine leak. The fix registers both listeners once, alongside the other one-time setup (`clearSearch`, `handleModalInteraction`, etc.), and leaves the actual listener logic untouched.

### Accessibility

No accessibility-relevant behaviour changed; same listeners, same logic, just registered once.

### Screenshots

Not applicable, no visual change.

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
