### PR TITLE
🐛 fix: fix root-section pagination showing every post

### DIFF
--- a/templates/macros/list_posts.html
+++ b/templates/macros/list_posts.html
@@ -20,17 +20,26 @@
         {% endif %}
     {% endfor %}
 
+    {# Pinned posts are always shown separately on page 1, so exclude them from any paginated slice #}
+    {% set page_posts_without_pinned = [] %}
+    {% for post in posts %}
+        {% if not post.extra.pinned %}
+            {% set_global page_posts_without_pinned = page_posts_without_pinned | concat(with=post) %}
+        {% endif %}
+    {% endfor %}
+
     {# On page 1 or when no pagination, show pinned then regular #}
     {% if current_page == 1 %}
         {% if paginator %}
             {# With pagination: pinned + current page's posts #}
-            {% set display_posts = pinned_posts | concat(with=posts) %}
+            {% set display_posts = pinned_posts | concat(with=page_posts_without_pinned) %}
         {% else %}
             {# Without pagination: pinned + regular (no duplicates) #}
             {% set display_posts = pinned_posts | concat(with=regular_posts) %}
         {% endif %}
     {% else %}
-        {% set display_posts = posts %}
+        {# Later pages: pinned posts already shown on page 1 #}
+        {% set display_posts = page_posts_without_pinned %}
     {% endif %}
 {% else %}
     {% set display_posts = posts %}

--- a/templates/partials/main_page_posts_list.html
+++ b/templates/partials/main_page_posts_list.html
@@ -51,7 +51,8 @@
             language_strings=language_strings,
             section_path=extra_section.path | default(value="blog"),
             pinned_first=is_root_section,
-            current_page=paginator.current_index | default(value=1)
+            current_page=paginator.current_index | default(value=1),
+            paginator=paginator | default(value="")
         ) }}
     </div>
 


### PR DESCRIPTION
## Summary

Fixes root-section pagination rendering every post on page 1, and a related pinned-post duplicate.

### Related issue

Resolves #668

## Changes

`main_page_posts_list.html` called the `list_posts` macro without `paginator=paginator`, so the macro's `{% if paginator %}` branch never fired for the root section. Page 1 fell into the no-pagination path, which concatenates pinned posts with every regular post in the section instead of just the current page's slice.

Passing `paginator` through fixed the main issue but surfaced a second one: a pinned post that also falls within page 1's natural paginator slice rendered twice on that page. Fixed by excluding pinned posts from any paginated slice in `list_posts.html`, since they're already shown separately in the pinned section on page 1. This also stops a pinned post from reappearing on later pages.

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan