### PR TITLE
🐛 fix(series): fix reversed pagination not reordering series pages

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -209,7 +209,7 @@ Current section extra: {% if current_section %}{{ current_section.extra | json_e
                 {%- if "series" in loaded_section.extra and loaded_section.extra.series -%}
                     {%- set_global series_section = loaded_section -%}
                     {%- set_global series_ordered_pages = loaded_section.pages -%}
-                    {%- if loaded_section.paginated | default(value=0) > 0 and loaded_section.paginate_reversed -%}
+                    {%- if loaded_section.paginate_by | default(value=0) > 0 and loaded_section.paginate_reversed -%}
                         {%- set_global series_ordered_pages = loaded_section.pages | reverse -%}
                     {%- endif -%}
                     {%- break -%}


### PR DESCRIPTION
## Summary

Fix series pages never being reordered when a series section sets `paginate_reversed = true`.

### Related issue

Resolves #670

## Changes

`series_ordered_pages` is meant to hold the series pages in reading order, reversing the section's natural order when `paginate_by` and `paginate_reversed = true` are set (this is the documented way to make series read oldest-to-newest). The check that triggers the reversal read `loaded_section.paginated`, which is not a real Zola `Section` field, so it always fell through `default(value=0)` to false. The reversal never ran, regardless of `paginate_reversed`.

Fixed to check `loaded_section.paginate_by`, the actual field name.

Verified by building a series section with `paginate_by = 9999`, `paginate_reversed = true`, and three dated pages: before the fix the oldest page reported the last position (`$SERIES_PAGE_INDEX`) in its intro template; after the fix it correctly reports the first position.

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
