### PR TITLE
🐛 fix(series): use aria-label instead of aria_label in navigation links

### DIFF
--- a/templates/macros/series_page.html
+++ b/templates/macros/series_page.html
@@ -19,14 +19,14 @@ Parameters:
         {# Prepare variables for substitution #}
         {%- set series_title = series_section.title -%}
         {%- set series_permalink = series_section.permalink -%}
-        {%- set series_html_link = '<a href="' ~ series_section.permalink ~ '" aria_label="' ~ series_section.title ~ '">' ~ series_section.title ~ '</a>' -%}
+        {%- set series_html_link = '<a href="' ~ series_section.permalink ~ '" aria-label="' ~ series_section.title ~ '">' ~ series_section.title ~ '</a>' -%}
 		{# Build series pages list #}
 		{%- set series_pages_list = [] -%}
 		{%- for series_page in series_ordered_pages -%}
 			{%- if series_page.relative_path == page.relative_path -%}
 				{%- set series_pages_list_item = '<li>' ~ series_page.title ~ '</li>' -%}
 			{%- else -%}
-				{%- set series_pages_list_item = '<li><a href="' ~ series_page.permalink ~ '" aria_label="' ~ series_page.title ~ '">' ~ series_page.title ~ '</a></li>' -%}
+				{%- set series_pages_list_item = '<li><a href="' ~ series_page.permalink ~ '" aria-label="' ~ series_page.title ~ '">' ~ series_page.title ~ '</a></li>' -%}
 			{%- endif -%}
 			{%- set_global series_pages_list = series_pages_list | concat(with=series_pages_list_item) -%}
 		{%- endfor -%}
@@ -81,13 +81,13 @@ Parameters:
 		{%- if prev_page is defined -%}
 			{%- set prev_title = prev_page.title -%}
 			{%- set prev_permalink = prev_page.permalink -%}
-			{%- set prev_html_link = '<a href="' ~ prev_page.permalink ~ '" aria_label="' ~ prev_page.title ~ '">' ~ prev_page.title ~ '</a>' -%}
+			{%- set prev_html_link = '<a href="' ~ prev_page.permalink ~ '" aria-label="' ~ prev_page.title ~ '">' ~ prev_page.title ~ '</a>' -%}
 			{%- set prev_description = prev_page.description | default(value="") -%}
 		{%- endif -%}
 		{%- if next_page is defined -%}
 			{%- set next_title = next_page.title -%}
 			{%- set next_permalink = next_page.permalink -%}
-			{%- set next_html_link = '<a href="' ~ next_page.permalink ~ '" aria_label="' ~ next_page.title ~ '">' ~ next_page.title ~ '</a>' -%}
+			{%- set next_html_link = '<a href="' ~ next_page.permalink ~ '" aria-label="' ~ next_page.title ~ '">' ~ next_page.title ~ '</a>' -%}
 			{%- set next_description = next_page.description | default(value="") -%}
 		{%- endif -%}
 


### PR DESCRIPTION
## Summary

Fix series navigation links using `aria_label` (underscore) instead of `aria-label` (hyphen), so they have no accessible name.

### Related issue

Resolves #674

## Changes

`templates/macros/series_page.html` builds the series intro, outro, and prev/next links as raw HTML strings. Four of these strings used `aria_label` instead of `aria-label`. Browsers and assistive technology only recognise the hyphenated attribute; the underscore version is not a valid ARIA attribute, so these links had no accessible name for screen readers.

Fixed by changing `aria_label` to `aria-label` in all four places (series intro link, series pages list items, prev link, next link).

### Accessibility

This PR is an accessibility fix: it restores the accessible name on series intro, outro, and prev/next navigation links for screen reader users.

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [ ] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
