### PR TITLE
🔒 fix(webmentions): escape and sanitise reply/mention content

### DIFF
--- a/static/js/webmention.js
+++ b/static/js/webmention.js
@@ -158,6 +158,55 @@ A more detailed example:
     return filtered;
   }
 
+  const SANITIZE_ALLOWED_TAGS = ['A', 'B', 'STRONG', 'I', 'EM', 'P', 'BR', 'BLOCKQUOTE', 'CODE', 'PRE', 'UL', 'OL', 'LI', 'IMG'];
+  /**
+   * Strip a reply's HTML down to an allow-listed set of tags/attributes.
+   * Reply content is untrusted third-party HTML from the sender's page.
+   *
+   * @param {string} html
+   * @returns string
+   */
+  function sanitizeHtml(html) {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    function clean(node) {
+      Array.prototype.slice.call(node.childNodes).forEach(function (child) {
+        if (child.nodeType === Node.COMMENT_NODE) {
+          node.removeChild(child);
+          return;
+        }
+        if (child.nodeType !== Node.ELEMENT_NODE) {
+          return;
+        }
+        if (SANITIZE_ALLOWED_TAGS.indexOf(child.tagName) === -1) {
+          clean(child);
+          while (child.firstChild) {
+            node.insertBefore(child.firstChild, child);
+          }
+          node.removeChild(child);
+          return;
+        }
+        const href = child.tagName === 'A' ? child.getAttribute('href') : null;
+        const src = child.tagName === 'IMG' ? child.getAttribute('src') : null;
+        const alt = child.tagName === 'IMG' ? child.getAttribute('alt') : null;
+        Array.prototype.slice.call(child.attributes).forEach(function (attr) {
+          child.removeAttribute(attr.name);
+        });
+        if (href !== null && /^https?:\/\//i.test(href.trim())) {
+          child.setAttribute('href', href);
+          child.setAttribute('rel', 'noreferrer');
+        }
+        if (src !== null && /^https?:\/\//i.test(src.trim())) {
+          child.setAttribute('src', src);
+          child.setAttribute('alt', alt || '');
+        }
+        clean(child);
+      });
+    }
+    clean(doc.body);
+    return doc.body.innerHTML;
+  }
+
+
   /**
    * Format comments as HTML.
    *
@@ -174,9 +223,9 @@ A more detailed example:
       let content = '';
       if (comment.hasOwnProperty('content')) {
         if (comment.content.hasOwnProperty('html')) {
-          content = comment.content.html;
+          content = sanitizeHtml(comment.content.html);
         } else if (comment.content.hasOwnProperty('text')) {
-          content = comment.content.text;
+          content = escapeHtml(comment.content.text);
         }
       }
 
@@ -184,12 +233,12 @@ A more detailed example:
   <li class="comment h-entry">
     <div>
       <a class="comment_author u-author"
-         href="`+ comment.author.url + `"
+         href="`+ escapeHtml(comment.author.url) + `"
          target="_blank"
-         title="`+ comment.author.name + `"
+         title="`+ escapeHtml(comment.author.name) + `"
          rel="noreferrer">
         <img
-          src="`+ comment.author.photo + `"
+          src="`+ escapeHtml(comment.author.photo) + `"
           alt=""
           class="u-photo"
           loading="lazy"
@@ -197,19 +246,19 @@ A more detailed example:
           width="48"
           height="48"
         >
-        <span class="p-author">`+ comment.author.name + `</span>
+        <span class="p-author">`+ escapeHtml(comment.author.name) + `</span>
       </a>`;
       if (comment.published) {
         const published = new Date(comment.published);
         html += `
-      <time class="dt-published" datetime="`+ comment.published + `">` + published.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" }) + `</time>`;
+      <time class="dt-published" datetime="`+ escapeHtml(comment.published) + `">` + published.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" }) + `</time>`;
       }
       html += `
     </div>
 
     <p class="e-entry">`+ content + `
       <a class="u-url"
-         href="`+ comment.url + `"
+         href="`+ escapeHtml(comment.url) + `"
          target="_blank"
          rel="noreferrer">
         source

--- a/static/js/webmention.min.js
+++ b/static/js/webmention.min.js
@@ -1,16 +1,16 @@
-!function(){"use strict";function t(t,e){return document.currentScript.getAttribute("data-"+t)||e}window.i18next=window.i18next||{t:function(t){return t}},window.i18next.t.bind(window.i18next);const g=t("page-url",window.location.href.replace(/#.*$/,"")),w=t("add-urls",void 0),e=t("id","webmentions"),f=(t("wordcount"),t("max-webmentions",30)),v=(t("prevent-spoofing"),t("sort-by","published")),b=t("sort-dir","up");function y(t){return t.substr(t.indexOf("//"))}function x(t){const l=[],a={};return t.forEach(function(t){var e=y(t.url);a[e]||(l.push(t),a[e]=!0)}),l}function L(t,e){let a=`
+!function(){"use strict";function t(t,e){return document.currentScript.getAttribute("data-"+t)||e}window.i18next=window.i18next||{t:function(t){return t}},window.i18next.t.bind(window.i18next);const f=t("page-url",window.location.href.replace(/#.*$/,"")),g=t("add-urls",void 0),e=t("id","webmentions"),w=(t("wordcount"),t("max-webmentions",30)),v=(t("prevent-spoofing"),t("sort-by","published")),b=t("sort-dir","up");function y(t){return t.substr(t.indexOf("//"))}function L(t){const r=[],l={};return t.forEach(function(t){var e=y(t.url);l[e]||(r.push(t),l[e]=!0)}),r}function x(t,e){let l=`
   <div class="webcomments">
-    <h3 id="replies-header">`+n("comment")+"&nbsp;<span>"+e.length+"</span> "+t+`s </h3>
-    <ol aria-labelledby="replies-header" role="list">`;return e.forEach(function(t){let e="";var l;t.hasOwnProperty("content")&&(t.content.hasOwnProperty("html")?e=t.content.html:t.content.hasOwnProperty("text")&&(e=t.content.text)),a+=`
+    <h3 id="replies-header">`+a("comment")+"&nbsp;<span>"+e.length+"</span> "+t+`s </h3>
+    <ol aria-labelledby="replies-header" role="list">`;return e.forEach(function(t){let e="";var r;t.hasOwnProperty("content")&&(t.content.hasOwnProperty("html")?e=(r=t.content.html,function a(n){Array.prototype.slice.call(n.childNodes).forEach(function(e){if(e.nodeType===Node.COMMENT_NODE)n.removeChild(e);else if(e.nodeType===Node.ELEMENT_NODE)if(-1===o.indexOf(e.tagName)){for(a(e);e.firstChild;)n.insertBefore(e.firstChild,e);n.removeChild(e)}else{var t="A"===e.tagName?e.getAttribute("href"):null,r="IMG"===e.tagName?e.getAttribute("src"):null,l="IMG"===e.tagName?e.getAttribute("alt"):null;Array.prototype.slice.call(e.attributes).forEach(function(t){e.removeAttribute(t.name)}),null!==t&&/^https?:\/\//i.test(t.trim())&&(e.setAttribute("href",t),e.setAttribute("rel","noreferrer")),null!==r&&/^https?:\/\//i.test(r.trim())&&(e.setAttribute("src",r),e.setAttribute("alt",l||"")),a(e)}})}((r=(new DOMParser).parseFromString(r,"text/html")).body),r.body.innerHTML):t.content.hasOwnProperty("text")&&(e=n(t.content.text))),l+=`
   <li class="comment h-entry">
     <div>
       <a class="comment_author u-author"
-         href="`+t.author.url+`"
+         href="`+n(t.author.url)+`"
          target="_blank"
-         title="`+t.author.name+`"
+         title="`+n(t.author.name)+`"
          rel="noreferrer">
         <img
-          src="`+t.author.photo+`"
+          src="`+n(t.author.photo)+`"
           alt=""
           class="u-photo"
           loading="lazy"
@@ -18,49 +18,49 @@
           width="48"
           height="48"
         >
-        <span class="p-author">`+t.author.name+`</span>
-      </a>`,t.published&&(l=new Date(t.published),a+=`
-      <time class="dt-published" datetime="`+t.published+'">'+l.toLocaleString(void 0,{dateStyle:"medium",timeStyle:"short"})+"</time>"),a+=`
+        <span class="p-author">`+n(t.author.name)+`</span>
+      </a>`,t.published&&(r=new Date(t.published),l+=`
+      <time class="dt-published" datetime="`+n(t.published)+'">'+r.toLocaleString(void 0,{dateStyle:"medium",timeStyle:"short"})+"</time>"),l+=`
     </div>
 
     <p class="e-entry">`+e+`
       <a class="u-url"
-         href="`+t.url+`"
+         href="`+n(t.url)+`"
          target="_blank"
          rel="noreferrer">
         source
       </a>
     </p>
   </li>
-`}),a+=`
+`}),l+=`
     </ol >
   </div >
-      `}function n(t){return"like"==t?'<svg focusable = "false" width = "24" height = "24" viewBox = "0 0 192 192" xmlns = "http://www.w3.org/2000/svg" > <path d="M95.997 41.986l-.026-.035C85.746 28.36 68.428 21.423 51.165 24.881 30.138 29.094 15.004 47.558 15 69.003c0 24.413 14.906 47.964 39.486 70.086 8.43 7.586 17.437 14.468 26.444 20.533.728.49 1.444.967 2.148 1.43l1.39.909 1.355.872 1.317.835.645.403 1.259.78 1.194.726 1.032.619 1.38.807.418.236a6 6 0 005.864 0l1.138-.654 1.154-.684 1.118-.675.614-.376 1.26-.779a212 212 0 00.644-.403l1.317-.835 1.355-.872 1.39-.909c.704-.463 1.42-.94 2.148-1.43 9.007-6.065 18.015-12.947 26.444-20.533C162.094 116.967 177 93.416 177 69.004c-.004-21.446-15.138-39.91-36.165-44.123-17.07-3.42-34.174 3.323-44.43 16.568l-.408.537zm42.48-5.338c15.421 3.09 26.52 16.63 26.523 32.357 0 19.607-12.438 39.847-33.532 59.357l-1.316 1.205c-.22.201-.443.402-.666.603-7.977 7.18-16.548 13.727-25.118 19.498l-.745.5c-.74.494-1.466.973-2.177 1.437l-1.402.906-1.359.864-.662.416-1.292.8-.732.446-.73-.446-1.292-.8-.662-.416-1.36-.864-1.4-.906a235.406 235.406 0 01-2.923-1.937c-8.57-5.77-17.14-12.319-25.118-19.498l-.666-.603-1.316-1.205C39.438 108.852 27 88.612 27 69.004c.003-15.726 11.102-29.267 26.523-32.356 15.253-3.056 30.565 4.954 36.756 19.208l.204.478c2.084 4.878 9.009 4.85 11.053-.045 6.062-14.511 21.52-22.73 36.941-19.641z" fill="currentColor" /></svg> ':"repost"==t?'<svg focusable = "false" width = "24" height = "24" viewBox = "0 0 192 192" xmlns = "http://www.w3.org/2000/svg" > <path d="M18.472 146.335l-.075-.184a5.968 5.968 0 01-.216-.684l-.014-.056a5.643 5.643 0 01-.082-.397l-.013-.083a5.886 5.886 0 01-.072-.96V144c0-.157.006-.313.018-.467l.006-.075c.012-.132.028-.261.048-.39l.016-.095c.008-.05.017-.1.027-.149.005-.019.008-.038.012-.058.028-.133.06-.264.096-.393l.026-.088a5.86 5.86 0 01.482-1.159l.043-.077a5.642 5.642 0 01.31-.49l.015-.022.076-.104.044-.059a3.856 3.856 0 01.165-.208l.052-.061c.102-.12.21-.236.321-.348l18-18a6 6 0 018.661 8.303l-.175.183L38.484 138H120c23.196 0 42-18.804 42-42a6 6 0 0112 0c0 29.525-23.696 53.516-53.107 53.993L120 150H38.486l7.757 7.757a6 6 0 01.175 8.303l-.175.183a6 6 0 01-8.303.175l-.183-.175-18-18-.145-.151a6.036 6.036 0 01-.829-1.125l-.058-.105a4.08 4.08 0 01-.06-.114l-.04-.077a4.409 4.409 0 01-.139-.3l-.014-.036zM154.06 25.582l.183.175 18 18a6.036 6.036 0 01.974 1.276l.058.105c.02.035.038.07.056.105l.043.086a4.411 4.411 0 01.14.3l.014.036a5.965 5.965 0 01.291.868l.014.056c.032.13.059.263.082.397l.013.083a5.886 5.886 0 01.067.692v.014a6.11 6.11 0 01-.013.692l-.006.075a5.856 5.856 0 01-.048.39l-.016.095c-.008.05-.017.1-.027.149-.005.019-.008.038-.012.058-.028.133-.06.264-.096.393l-.026.088a5.86 5.86 0 01-.482 1.159l-.043.077-.052.09-.029.048a6.006 6.006 0 01-.32.478l-.044.059a3.857 3.857 0 01-.165.208l-.052.061a6.34 6.34 0 01-.176.197l-.145.15-18 18a6 6 0 01-8.661-8.302l.175-.183L153.514 54H72c-23.196 0-42 18.804-42 42a6 6 0 11-12 0c0-29.525 23.696-53.516 53.107-53.993L72 42h81.516l-7.759-7.757a6 6 0 01-.175-8.303l.175-.183a6 6 0 018.303-.175z" fill="currentColor" /></svg> ':"comment"==t?'<svg width = "24" height = "24" viewBox = "0 0 150 150" xmlns = "http://www.w3.org/2000/svg" > <path d="M75-.006a75 75 0 0174.997 74.31l.003.69c0 41.422-33.579 75-75 75H11.75c-6.49 0-11.75-5.26-11.75-11.75v-63.25a75 75 0 0175-75zm0 12a63 63 0 00-63 63v63h63c34.446 0 62.435-27.645 62.992-61.93l.008-1.041-.003-.633A63 63 0 0075 11.994zm21 72a6 6 0 01.225 11.996l-.225.004H51a6 6 0 01-.225-11.996l.225-.004h45zm0-24a6 6 0 01.225 11.996l-.225.004H51a6 6 0 01-.225-11.996l.225-.004h45z" fill="currentColor" /></svg> ':"bookmark"==t?`<svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24">
+      `}function a(t){return"like"==t?'<svg focusable = "false" width = "24" height = "24" viewBox = "0 0 192 192" xmlns = "http://www.w3.org/2000/svg" > <path d="M95.997 41.986l-.026-.035C85.746 28.36 68.428 21.423 51.165 24.881 30.138 29.094 15.004 47.558 15 69.003c0 24.413 14.906 47.964 39.486 70.086 8.43 7.586 17.437 14.468 26.444 20.533.728.49 1.444.967 2.148 1.43l1.39.909 1.355.872 1.317.835.645.403 1.259.78 1.194.726 1.032.619 1.38.807.418.236a6 6 0 005.864 0l1.138-.654 1.154-.684 1.118-.675.614-.376 1.26-.779a212 212 0 00.644-.403l1.317-.835 1.355-.872 1.39-.909c.704-.463 1.42-.94 2.148-1.43 9.007-6.065 18.015-12.947 26.444-20.533C162.094 116.967 177 93.416 177 69.004c-.004-21.446-15.138-39.91-36.165-44.123-17.07-3.42-34.174 3.323-44.43 16.568l-.408.537zm42.48-5.338c15.421 3.09 26.52 16.63 26.523 32.357 0 19.607-12.438 39.847-33.532 59.357l-1.316 1.205c-.22.201-.443.402-.666.603-7.977 7.18-16.548 13.727-25.118 19.498l-.745.5c-.74.494-1.466.973-2.177 1.437l-1.402.906-1.359.864-.662.416-1.292.8-.732.446-.73-.446-1.292-.8-.662-.416-1.36-.864-1.4-.906a235.406 235.406 0 01-2.923-1.937c-8.57-5.77-17.14-12.319-25.118-19.498l-.666-.603-1.316-1.205C39.438 108.852 27 88.612 27 69.004c.003-15.726 11.102-29.267 26.523-32.356 15.253-3.056 30.565 4.954 36.756 19.208l.204.478c2.084 4.878 9.009 4.85 11.053-.045 6.062-14.511 21.52-22.73 36.941-19.641z" fill="currentColor" /></svg> ':"repost"==t?'<svg focusable = "false" width = "24" height = "24" viewBox = "0 0 192 192" xmlns = "http://www.w3.org/2000/svg" > <path d="M18.472 146.335l-.075-.184a5.968 5.968 0 01-.216-.684l-.014-.056a5.643 5.643 0 01-.082-.397l-.013-.083a5.886 5.886 0 01-.072-.96V144c0-.157.006-.313.018-.467l.006-.075c.012-.132.028-.261.048-.39l.016-.095c.008-.05.017-.1.027-.149.005-.019.008-.038.012-.058.028-.133.06-.264.096-.393l.026-.088a5.86 5.86 0 01.482-1.159l.043-.077a5.642 5.642 0 01.31-.49l.015-.022.076-.104.044-.059a3.856 3.856 0 01.165-.208l.052-.061c.102-.12.21-.236.321-.348l18-18a6 6 0 018.661 8.303l-.175.183L38.484 138H120c23.196 0 42-18.804 42-42a6 6 0 0112 0c0 29.525-23.696 53.516-53.107 53.993L120 150H38.486l7.757 7.757a6 6 0 01.175 8.303l-.175.183a6 6 0 01-8.303.175l-.183-.175-18-18-.145-.151a6.036 6.036 0 01-.829-1.125l-.058-.105a4.08 4.08 0 01-.06-.114l-.04-.077a4.409 4.409 0 01-.139-.3l-.014-.036zM154.06 25.582l.183.175 18 18a6.036 6.036 0 01.974 1.276l.058.105c.02.035.038.07.056.105l.043.086a4.411 4.411 0 01.14.3l.014.036a5.965 5.965 0 01.291.868l.014.056c.032.13.059.263.082.397l.013.083a5.886 5.886 0 01.067.692v.014a6.11 6.11 0 01-.013.692l-.006.075a5.856 5.856 0 01-.048.39l-.016.095c-.008.05-.017.1-.027.149-.005.019-.008.038-.012.058-.028.133-.06.264-.096.393l-.026.088a5.86 5.86 0 01-.482 1.159l-.043.077-.052.09-.029.048a6.006 6.006 0 01-.32.478l-.044.059a3.857 3.857 0 01-.165.208l-.052.061a6.34 6.34 0 01-.176.197l-.145.15-18 18a6 6 0 01-8.661-8.302l.175-.183L153.514 54H72c-23.196 0-42 18.804-42 42a6 6 0 11-12 0c0-29.525 23.696-53.516 53.107-53.993L72 42h81.516l-7.759-7.757a6 6 0 01-.175-8.303l.175-.183a6 6 0 018.303-.175z" fill="currentColor" /></svg> ':"comment"==t?'<svg width = "24" height = "24" viewBox = "0 0 150 150" xmlns = "http://www.w3.org/2000/svg" > <path d="M75-.006a75 75 0 0174.997 74.31l.003.69c0 41.422-33.579 75-75 75H11.75c-6.49 0-11.75-5.26-11.75-11.75v-63.25a75 75 0 0175-75zm0 12a63 63 0 00-63 63v63h63c34.446 0 62.435-27.645 62.992-61.93l.008-1.041-.003-.633A63 63 0 0075 11.994zm21 72a6 6 0 01.225 11.996l-.225.004H51a6 6 0 01-.225-11.996l.225-.004h45zm0-24a6 6 0 01.225 11.996l-.225.004H51a6 6 0 01-.225-11.996l.225-.004h45z" fill="currentColor" /></svg> ':"bookmark"==t?`<svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24">
 <path d="M 6.0097656 2 C 4.9143111 2 4.0097656 2.9025988 4.0097656 3.9980469 L 4 22 L 12 19 L 20 22 L 20 20.556641 L 20 4 C 20 2.9069372 19.093063 2 18 2 L 6.0097656 2 z M 6.0097656 4 L 18 4 L 18 19.113281 L 12 16.863281 L 6.0019531 19.113281 L 6.0097656 4 z" fill="currentColor"></path>
-</svg>`:void 0}function a(t){return String(t).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#39;")}function k(t,e){let l=`
+</svg>`:void 0}function n(t){return String(t).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#39;")}const o=["A","B","STRONG","I","EM","P","BR","BLOCKQUOTE","CODE","PRE","UL","OL","LI","IMG"];function E(t,e){let r=`
       <div class="color--primary">
-        <h3 id="`+t+'-header">'+n(t)+"&nbsp;<span>"+e.length+"</span> "+t+`s</h3>
+        <h3 id="`+t+'-header">'+a(t)+"&nbsp;<span>"+e.length+"</span> "+t+`s</h3>
 
-          <ol class="likes" role="list" aria-labelledby="`+t+'-header">';return e.forEach(function(t){l+=`
+          <ol class="likes" role="list" aria-labelledby="`+t+'-header">';return e.forEach(function(t){r+=`
             <li class="h-card">
               <a class="u-url"
-                href="`+a(t.author.url)+`"
+                href="`+n(t.author.url)+`"
                 target="_blank"
                 rel="noreferrer"
-                title="`+a(t.author.name)+`">
+                title="`+n(t.author.name)+`">
       <img
         alt=""
         class="lazy mentions__image u-photo"
-        src="`+a(t.author.photo)+`"
+        src="`+n(t.author.photo)+`"
         loading="lazy"
         decoding="async"
         width="48"
         height="48"
       >
-        <span class="p-author visually-hidden" aria-hidden="true">`+a(t.author.name)+`</span>
+        <span class="p-author visually-hidden" aria-hidden="true">`+n(t.author.name)+`</span>
       </a>
   </li>
-      `}),l+=`
+      `}),r+=`
     </ol >
   </div >
-      `}window.addEventListener("load",async function(){var i=document.getElementById(e);if(i){const p=[y(g)];w&&w.split("|").forEach(function(t){p.push(y(t))});let e=`https://webmention.io/api/mentions.jf2?per-page=${f}&sort-by=${v}&sort-dir=`+b,t=(p.forEach(function(t){e+=`&target[]=${encodeURIComponent("http:"+t)}&target[]=`+encodeURIComponent("https:"+t)}),{});try{200<=(s=await window.fetch(e)).status&&s.status<300?t=await s.json():console.error("Could not parse response",s.statusText)}catch(t){console.error("Request failed",t)}var s,c=[],h=[],u=[],d=[];const m={"in-reply-to":s=[],"like-of":u,"repost-of":d,"bookmark-of":h,"follow-of":[],"mention-of":c,rsvp:s};(t.children||[]).forEach(function(t){var e=m[t["wm-property"]];e&&e.push(t)});let l="",a=(0<c.length&&(l=L("mention",x(c))),""),n=(0<s.length&&(a=L("comment",x(s))),""),o=(0<u.length&&(n=k("like",x(u))),""),r=(0<d.length&&(o=k("repost",x(d))),"");0<h.length&&(r=k("bookmark",x(h))),i.innerHTML=`<div id="webmentions">${o}${n}${r}${a}${l}</div>`}})}();
+      `}window.addEventListener("load",async function(){var i=document.getElementById(e);if(i){const p=[y(f)];g&&g.split("|").forEach(function(t){p.push(y(t))});let e=`https://webmention.io/api/mentions.jf2?per-page=${w}&sort-by=${v}&sort-dir=`+b,t=(p.forEach(function(t){e+=`&target[]=${encodeURIComponent("http:"+t)}&target[]=`+encodeURIComponent("https:"+t)}),{});try{200<=(s=await window.fetch(e)).status&&s.status<300?t=await s.json():console.error("Could not parse response",s.statusText)}catch(t){console.error("Request failed",t)}var s,c=[],h=[],u=[],d=[];const m={"in-reply-to":s=[],"like-of":u,"repost-of":d,"bookmark-of":h,"follow-of":[],"mention-of":c,rsvp:s};(t.children||[]).forEach(function(t){var e=m[t["wm-property"]];e&&e.push(t)});let r="",l=(0<c.length&&(r=x("mention",L(c))),""),a=(0<s.length&&(l=x("comment",L(s))),""),n=(0<u.length&&(a=E("like",L(u))),""),o=(0<d.length&&(n=E("repost",L(d))),"");0<h.length&&(o=E("bookmark",L(h))),i.innerHTML=`<div id="webmentions">${n}${a}${o}${l}${r}</div>`}})}();


### PR DESCRIPTION
## Summary

Escape and sanitize webmention reply/mention content before it's rendered, fixing a stored-XSS vector.

### Related issue

Resolves #678

## Changes

`formatComments()` built each reply/mention's markup by concatenating `comment.author.name`, `comment.author.url`, `comment.author.photo`, `comment.url`, and `comment.published` directly into HTML attributes and text nodes, with no escaping. `comment.content.html` was inserted as raw HTML with no filtering at all. All of these values come from the webmention sender's own page, parsed by webmention.io, so they're third-party, unauthenticated input.

Reused the `escapeHtml()` helper (added in #677) for the plain-text/attribute fields. For `content.html`, added a `sanitizeHtml()` helper: it parses the string with `DOMParser` and walks the resulting tree, keeping only an allow-list of tags (`a`, `b`, `strong`, `i`, `em`, `p`, `br`, `blockquote`, `code`, `pre`, `ul`, `ol`, `li`, `img`), stripping every attribute except a scheme-checked `href` on `<a>` and `src`/`alt` on `<img>` (only `http(s)` URLs survive, so `javascript:` links/images are dropped). Anything not on the allow-list is unwrapped to its text content rather than dropped outright, so a reply's actual wording is preserved. `content.text` is now escaped instead of inserted raw.

### Accessibility

`<img>` in reply content keeps its `alt` text; everything else affecting assistive tech (heading/list association) was already fixed in #677 and untouched here.

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
