### PR TITLE
🐛 fix(comments): fix Isso sharing one thread when page_id_is_slug is false

### DIFF
--- a/templates/partials/comments.html
+++ b/templates/partials/comments.html
@@ -69,6 +69,9 @@
     {%- set default_lang_url = current_path | replace(from='/' ~ lang ~ '/', to = '/') -%}
         data-isso-id="{{ default_lang_url }}"
         data-title="{{ default_lang_url }}"
+    {% else %}
+        data-isso-id="{{ current_url }}"
+        data-title="{{ current_url }}"
     {% endif %}
     {% if config.extra.isso.lang  %}
         data-page-language="{{ config.extra.isso.lang }}"


### PR DESCRIPTION
## Summary

Fix Isso comments sharing a single thread across all pages when `page_id_is_slug = false`.

### Related issue

Resolves #681

## Changes

`templates/partials/comments.html` only set `data-isso-id`/`data-title` on the `#comments` div when `page_id_is_slug` was true. When it was false, neither attribute was rendered at all.

`static/js/isso.js` then read the missing `data-isso-id` attribute as `null` and passed it straight into `section.setAttribute('data-isso-id', pageId)`. `setAttribute` stringifies `null` to the literal string `"null"`, so every page ended up with `data-isso-id="null"` and Isso grouped all of them into one thread.

Added the missing `else` branch, setting `data-isso-id`/`data-title` to `current_url`, matching the documented behaviour ("If false, it will use the entire url as id.") and mirroring how the `hyvortalk` branch above it already does the same thing.

Verified by building the site with `page_id_is_slug = false`: different pages now render distinct `data-isso-id` values (e.g. `.../blog/comments/` vs `.../blog/javascript/`) instead of no attribute at all.

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
