### PR TITLE
🐛 fix(webmentions): respect multiple webmention options

### DIFF
--- a/templates/partials/webmentions.html
+++ b/templates/partials/webmentions.html
@@ -10,7 +10,7 @@
 {% set script_data = "" %}
 
 {% if config.extra.webmentions.id %}
-{% set script_data = script_data ~ "data-id=" ~ config.extra.webmentions.id %}
+{% set script_data = script_data ~ " data-id=" ~ config.extra.webmentions.id %}
 {% endif %}
 
 {% if config.extra.webmentions.page_url %}
@@ -18,7 +18,7 @@
 {% endif %}
 
 {% if config.extra.webmentions.add_urls %}
-{% set script_data = script_data ~ "data-add-urls=" ~ config.extra.webmentions.add_urls %}
+{% set script_data = script_data ~ " data-add-urls=" ~ config.extra.webmentions.add_urls %}
 {% endif %}
 
 {% if config.extra.webmentions.wordcount %}
@@ -26,19 +26,19 @@
 {% endif %}
 
 {% if config.extra.webmentions.max_webmentions %}
-{% set script_data = script_data ~ "data-max-webmentions=" ~ config.extra.webmentions.max_webmentions %}
+{% set script_data = script_data ~ " data-max-webmentions=" ~ config.extra.webmentions.max_webmentions %}
 {% endif %}
 
 {% if config.extra.webmentions.prevent_spoofing %}
-{% set script_data = script_data ~ "data-prevent-spoofing=" ~ config.extra.webmentions.prevent_spoofing %}
+{% set script_data = script_data ~ " data-prevent-spoofing=" ~ config.extra.webmentions.prevent_spoofing %}
 {% endif %}
 
 {% if config.extra.webmentions.sort_by %}
-{% set script_data = script_data ~ "data-sort-by=" ~ config.extra.webmentions.sort_by %}
+{% set script_data = script_data ~ " data-sort-by=" ~ config.extra.webmentions.sort_by %}
 {% endif %}
 
 {% if config.extra.webmentions.sort_dir %}
-{% set script_data = script_data ~ "data-sort-dir=" ~ config.extra.webmentions.sort_dir %}
+{% set script_data = script_data ~ " data-sort-dir=" ~ config.extra.webmentions.sort_dir %}
 {% endif %}
 
 {% if config.extra.webmentions.comments_are_reactions %}


### PR DESCRIPTION
## Summary

Fix webmention script data attributes fusing together when more than one `[extra.webmentions]` option is configured.

### Related issue

Resolves #683

## Changes

`script_data` in `templates/partials/webmentions.html` is built by concatenating each `data-*` chunk onto the previous one. Since the resulting attributes are unquoted in the HTML, each chunk needs a leading space to separate it from whatever precedes it. Most branches (`id`, `add_urls`, `max_webmentions`, `prevent_spoofing`, `sort_by`, `sort_dir`) were missing that leading space, while a few (`page_url`, `wordcount`, `comments_are_reactions`) already had it.

Whenever two of the space-less options were set together, the second one had no separator from the first and got parsed as part of the first attribute's value instead of becoming its own attribute, so webmention.js never saw it.

The fix adds the missing leading space to every branch, so each option always becomes its own attribute regardless of which others are set alongside it.

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [x] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan