### PR TITLE
🐛 fix(taxonomies): improve custom taxonomies support

### DIFF
--- a/templates/partials/cards_pages.html
+++ b/templates/partials/cards_pages.html
@@ -16,7 +16,7 @@
             href="{{ target_url }}"
             class="card"
             {% if page.taxonomies %}
-            data-tags="{% for tax_name, terms in page.taxonomies %}{% for term in terms | unique %}{{ term | lower }}{% if not loop.last %},{% endif %}{% endfor %}{% endfor %}"
+            data-tags="{%- set_global is_first_tag = true -%}{% for tax_name, terms in page.taxonomies %}{% for term in terms | unique %}{% if not is_first_tag %},{% endif %}{% set_global is_first_tag = false %}{{ term | lower }}{% endfor %}{% endfor %}"
             {% endif %}>
             {% if page.extra.invertible_image %}{% set card_image_class = "card-image invertible-image" %}{% else %}{% set card_image_class = "card-image" %}{% endif %}
             {% if page.extra.local_image_dark and not page.extra.local_image %}

--- a/templates/partials/filter_card_tags.html
+++ b/templates/partials/filter_card_tags.html
@@ -1,19 +1,19 @@
-{#- Collect all terms. -#}
+{#- Collect all terms, paired with their taxonomy so we know which kind to look them up under. -#}
 {#- We don't use `get_taxonomy` so users aren't forced to use 'tags' -#}
 {% set all_terms = [] %}
 {% for page in show_pages %}
     {% if page.taxonomies %}
         {% for tax_name, terms in page.taxonomies %}
             {% for term in terms %}
-                {% set_global all_terms = all_terms | concat(with=term) %}
+                {% set_global all_terms = all_terms | concat(with=tax_name ~ "::" ~ term) %}
             {% endfor %}
         {% endfor %}
     {% endif %}
 {% endfor %}
 
 {#- Display unique terms -#}
-{% set unique_terms = all_terms | unique | sort %}
-{%- if unique_terms | length >= 2 -%}
+{% set unique_pairs = all_terms | unique | sort %}
+{%- if unique_pairs | length >= 2 -%}
     <ul class="filter-controls" role="group" aria-label="{{ macros_translate::translate(key='project_filters', default='Project filters', language_strings=language_strings) }}">
         <li class="taxonomy-item no-hover-padding">
             <a id="all-projects-filter" class="no-hover-padding active"
@@ -22,10 +22,12 @@
                 {{- macros_translate::translate(key="all_projects", default="All projects", language_strings=language_strings) -}}
             </a>
         </li>
-        {% for term in unique_terms %}
+        {% for pair in unique_pairs %}
+            {% set tax_name = pair | split(pat="::") | first %}
+            {% set term = pair | split(pat="::") | last %}
             <li class="taxonomy-item no-hover-padding">
                 <a class="no-hover-padding"
-                href="{{ get_taxonomy_url(kind="tags", name=term, lang=lang) }}"
+                href="{{ get_taxonomy_url(kind=tax_name, name=term, lang=lang) }}"
                 data-filter="{{ term | lower }}">{{ term }}</a>
             </li>
         {% endfor %}

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -15,7 +15,7 @@
 
 <ul class="pagination">
     <li class="page-item">
-        <a class="all-tags" href="{{ get_url(path="tags", lang=lang) }}/"><span class="arrow">←</span>&nbsp;{{- macros_translate::translate(key=taxonomy.name, default=taxonomy.name, language_strings=language_strings) -}}</a>
+        <a class="all-tags" href="{{ get_url(path=taxonomy.name, lang=lang) }}/"><span class="arrow">←</span>&nbsp;{{- macros_translate::translate(key=taxonomy.name, default=taxonomy.name, language_strings=language_strings) -}}</a>
     </li>
 </ul>
 


### PR DESCRIPTION
## Summary

Fixes three bugs that break support for a second (non-`tags`) taxonomy on project cards.

### Related issue

Resolves #685

## Changes

All three bugs share the same root cause: several project-card templates were written assuming `tags` is the only taxonomy, even though `filter_card_tags.html`'s own comment says it deliberately avoids `get_taxonomy` so users aren't forced into a taxonomy named `tags`.

- **Build crash**: `filter_card_tags.html` called `get_taxonomy_url(kind="tags", ...)` for every filter term regardless of which taxonomy it actually belonged to, so looking up a term from a second taxonomy under `kind="tags"` failed and aborted the build. Now each term is collected as a `taxonomy::term` pair, so the correct `kind` is passed through.
- **Wrong archive back-link**: `taxonomy_single.html` hardcoded its "back" link to `get_url(path="tags", ...)` even though the same line already parameterises the visible label by `taxonomy.name`. Now the link uses `taxonomy.name` too, so it points to the taxonomy's own archive instead of always `/tags/`.
- **Fused `data-tags` values**: `cards_pages.html` built the `data-tags` attribute with a nested loop over `page.taxonomies`, but used `loop.last` to decide whether to emit a separator, which only refers to the inner (per-taxonomy) loop. Terms from different taxonomies ran together with no separator (e.g. `plannerinteractive`). Now a flag tracks whether any term has been emitted yet, across both loops.

All three were verified with a `zola build` reproduction using two taxonomies (`tags` and a second `categories`), and against the existing single-taxonomy (`tags`-only) site to confirm no regressions.

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
