### PR TITLE
🐛 fix(feed): escape ampersands in Atom feed title

### DIFF
--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -47,7 +47,7 @@
         <link rel="extra-stylesheet" href="{{ get_url(path='skins/' ~ config.extra.skin ~ '.css', cachebust=true) | safe }}" />
     {%- endif -%}
 
-    <title>{{ config.title | striptags | safe }}
+    <title>{{ config.title | striptags | escape_xml | safe }}
     {%- if term %} - {{ term.name }}
     {%- elif section.title %} - {{ section.title }}
     {%- endif -%}


### PR DESCRIPTION
## Summary

Fix invalid Atom feed XML when the site title contains a bare `&`.

### Related issue

Resolves #687

## Changes

`atom.xml` builds the feed's `<title>` from `config.title | striptags | safe`. The `| safe` filter disables Tera's auto-escaping, so a literal `&` in the title is written straight into the XML instead of being encoded as `&amp;`, producing a feed that strict XML parsers reject.

The rest of this template already escapes untrusted values with `escape_xml` before `| safe` (e.g. `term.permalink`, `section.permalink`); `config.title` was missing that step. Added `escape_xml` to the same filter chain.

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

## Checklist

- [ ] I have verified the accessibility of my changes
- [x] I have tested all possible scenarios for this change
- [ ] I have updated `theme.toml` with a sane default for the feature
- [ ] I have updated `config.toml` in [tabi-start](https://github.com/welpo/tabi-start)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Updated `config.toml` comments
  - [ ] Updated `theme.toml` comments
  - [ ] Updated "Mastering tabi" post in English
  - [ ] (Optional) Updated "Mastering tabi" post in Spanish
  - [ ] (Optional) Updated "Mastering tabi" post in Catalan
